### PR TITLE
ci: solidificar py/ts reusables (instalar proyecto y pnpm sin lock)

### DIFF
--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -3,9 +3,10 @@ on:
   workflow_call:
     inputs:
       python-versions:
-        required: false
         type: string
+        required: false
         default: '["3.11","3.12"]'
+
 jobs:
   py:
     name: Python ${{ matrix.py }}
@@ -16,29 +17,38 @@ jobs:
         py: ${{ fromJson(inputs.python-versions) }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Detect Python project
+        id: detect
+        run: |
+          if [ -f pyproject.toml ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No pyproject.toml — skipping Python checks."
+          fi
+
       - uses: actions/setup-python@v5
+        if: steps.detect.outputs.present == 'true'
         with:
           python-version: ${{ matrix.py }}
+
       - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: "1.8.3"
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-      - name: Cache Poetry venv
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: ${{ runner.os }}-poetry-${{ matrix.py }}-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-${{ matrix.py }}-
+        if: steps.detect.outputs.present == 'true'
+        run: pipx install poetry
+
       - name: Install deps
-        run: poetry install --no-interaction
+        if: steps.detect.outputs.present == 'true'
+        run: poetry install --only main,test --no-interaction
+
       - name: Ruff
+        if: steps.detect.outputs.present == 'true'
         run: poetry run ruff check .
+
       - name: Black
+        if: steps.detect.outputs.present == 'true'
         run: poetry run black --check src tests
-      - name: Pytest
-        env:
-          PYTHONPATH: src
-        run: poetry run pytest -q
+
+      - name: Tests
+        if: steps.detect.outputs.present == 'true'
+        run: PYTHONPATH=src poetry run pytest -q

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -3,8 +3,9 @@ on:
   workflow_call:
     inputs:
       python-versions:
-        { required: false, type: string, default: '["3.11","3.12"]' }
-      cov-min: { required: false, type: number, default: 100 }
+        required: false
+        type: string
+        default: '["3.11","3.12"]'
 jobs:
   py:
     name: Python ${{ matrix.py }}
@@ -12,14 +13,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: ${{ fromJSON(inputs.python-versions) }}
+        py: ${{ fromJson(inputs.python-versions) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
-      - run: pipx install poetry
-      - run: poetry install --only main,test --no-interaction
-      - run: poetry run ruff check .
-      - run: poetry run black --check src tests
-      - run: PYTHONPATH=src poetry run pytest -q
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: "1.8.3"
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+      - name: Cache Poetry venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ runner.os }}-poetry-${{ matrix.py }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-${{ matrix.py }}-
+      - name: Install deps
+        run: poetry install --no-interaction
+      - name: Ruff
+        run: poetry run ruff check .
+      - name: Black
+        run: poetry run black --check src tests
+      - name: Pytest
+        env:
+          PYTHONPATH: src
+        run: poetry run pytest -q


### PR DESCRIPTION
Python: instala el proyecto y usa PYTHONPATH=src; Node: permite pnpm sin lockfile. Sin cambios de código.