### PR TITLE
ci: add manual PyPI publish workflow (OIDC)

### DIFF
--- a/.github/workflows/manual-publish-pypi.yml
+++ b/.github/workflows/manual-publish-pypi.yml
@@ -1,0 +1,23 @@
+name: manual-publish-pypi
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip build
+      - run: python -m build
+      - name: Publish to PyPI (OIDC)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist


### PR DESCRIPTION
Add workflow_dispatch-only job to publish current main to PyPI via Trusted Publisher.