### PR TITLE
chore: add .editorconfig and .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{py,toml}]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+
+# No incluir meta en tarballs
+.github/ export-ignore
+.tools/ export-ignore
+tests/ export-ignore
+docs/ export-ignore


### PR DESCRIPTION
Normalize EOL to LF, enforce UTF-8, whitespace rules, and cleaner source tarballs. Local radar green.