### PR TITLE
ci: fix auto-assign workflow

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -1,5 +1,7 @@
 addReviewers: true
-addAssignees: author
+addAssignees: false
 reviewers:
   - CoderDeltaLAN
 numberOfReviewers: 1
+skipKeywords:
+  - skip-review

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,14 +1,14 @@
 name: auto-assign
 on:
   pull_request_target:
-    types: [opened, ready_for_review, reopened, synchronize]
+    types: [opened, ready_for_review, reopened]
 permissions:
   pull-requests: write
 jobs:
   assign:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.3.0
+      - uses: kentaro-m/auto-assign-action@v2.2.1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/auto-assign.yml


### PR DESCRIPTION
Use pull_request_target with pull-requests:write and provide config. Skip drafts and allow 'skip-review' label.