### PR TITLE
ci(auto-assign): pin action to v2.0.0

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -9,6 +9,6 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.2.1
+      - uses: kentaro-m/auto-assign-action@v2.0.0
         with:
           configuration-path: .github/auto-assign.yml


### PR DESCRIPTION
Fix failing runs: tag v2.3.0 does not exist; pin to v2.0.0. Keep pull_request_target + pull-requests: write.