### PR TITLE
ci(auto-assign): fix config path (.github/auto_assign.yml)

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,7 +1,8 @@
+# https://github.com/kentaro-m/auto-assign-action
 addReviewers: true
-addAssignees: false
+addAssignees: author
 reviewers:
   - CoderDeltaLAN
 numberOfReviewers: 1
 skipKeywords:
-  - skip-review
+  - WIP

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -9,6 +9,6 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.2.1
+      - uses: kentaro-m/auto-assign-action@v2.0.0
         with:
           configuration-path: .github/auto-assign.yml


### PR DESCRIPTION
Previous failures came from missing config file. Rename to the expected underscore name and provide minimal valid settings.