### PR TITLE
ci: fix OpenSSF Scorecard permissions + SARIF upload (private)

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,20 +17,20 @@ jobs:
   analysis:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      security-events: write
       contents: read
+      security-events: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - name: Run Scorecard
+      - name: Run Scorecard (private publish)
         uses: ossf/scorecard-action@v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          publish_results: false
 
       - name: Upload SARIF to code scanning
         uses: github/codeql-action/upload-sarif@v3

--- a/_ci_redfix/20250919-085657/scorecard-17853528080.log
+++ b/_ci_redfix/20250919-085657/scorecard-17853528080.log
@@ -1,0 +1,1597 @@
+analysis	Set up job	﻿2025-09-19T08:53:21.1443083Z Current runner version: '2.328.0'
+analysis	Set up job	2025-09-19T08:53:21.1471374Z ##[group]Runner Image Provisioner
+analysis	Set up job	2025-09-19T08:53:21.1472362Z Hosted Compute Agent
+analysis	Set up job	2025-09-19T08:53:21.1472898Z Version: 20250829.383
+analysis	Set up job	2025-09-19T08:53:21.1473514Z Commit: 27cb235aab5b0e52e153a26cd86b4742e89dac5d
+analysis	Set up job	2025-09-19T08:53:21.1474264Z Build Date: 2025-08-29T13:48:48Z
+analysis	Set up job	2025-09-19T08:53:21.1474840Z ##[endgroup]
+analysis	Set up job	2025-09-19T08:53:21.1475432Z ##[group]Operating System
+analysis	Set up job	2025-09-19T08:53:21.1476059Z Ubuntu
+analysis	Set up job	2025-09-19T08:53:21.1476827Z 24.04.3
+analysis	Set up job	2025-09-19T08:53:21.1477274Z LTS
+analysis	Set up job	2025-09-19T08:53:21.1477791Z ##[endgroup]
+analysis	Set up job	2025-09-19T08:53:21.1478286Z ##[group]Runner Image
+analysis	Set up job	2025-09-19T08:53:21.1478879Z Image: ubuntu-24.04
+analysis	Set up job	2025-09-19T08:53:21.1479432Z Version: 20250907.24.1
+analysis	Set up job	2025-09-19T08:53:21.1480435Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250907.24/images/ubuntu/Ubuntu2404-Readme.md
+analysis	Set up job	2025-09-19T08:53:21.1481833Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250907.24
+analysis	Set up job	2025-09-19T08:53:21.1483014Z ##[endgroup]
+analysis	Set up job	2025-09-19T08:53:21.1484183Z ##[group]GITHUB_TOKEN Permissions
+analysis	Set up job	2025-09-19T08:53:21.1486926Z Contents: read
+analysis	Set up job	2025-09-19T08:53:21.1487487Z Metadata: read
+analysis	Set up job	2025-09-19T08:53:21.1487992Z SecurityEvents: write
+analysis	Set up job	2025-09-19T08:53:21.1488615Z ##[endgroup]
+analysis	Set up job	2025-09-19T08:53:21.1491251Z Secret source: Actions
+analysis	Set up job	2025-09-19T08:53:21.1492171Z Prepare workflow directory
+analysis	Set up job	2025-09-19T08:53:21.1823084Z Prepare all required actions
+analysis	Set up job	2025-09-19T08:53:21.1863427Z Getting action download info
+analysis	Set up job	2025-09-19T08:53:21.5614822Z Download action repository 'actions/checkout@v4' (SHA:08eba0b27e820071cde6df949e0beb9ba4906955)
+analysis	Set up job	2025-09-19T08:53:21.7328754Z Download action repository 'ossf/scorecard-action@v2.3.1' (SHA:0864cf19026789058feabb7e87baa5f140aac736)
+analysis	Set up job	2025-09-19T08:53:22.0764946Z Download action repository 'github/codeql-action@v3' (SHA:192325c86100d080feab897ff886c34abd4c83a3)
+analysis	Set up job	2025-09-19T08:53:22.8610538Z Complete job name: analysis
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	﻿2025-09-19T08:53:22.9086511Z ##[group]Pull down action image 'gcr.io/openssf/scorecard-action:v2.3.1'
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:22.9141886Z ##[command]/usr/bin/docker pull gcr.io/openssf/scorecard-action:v2.3.1
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0583825Z v2.3.1: Pulling from openssf/scorecard-action
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0586015Z 07a64a71e011: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0587267Z fe5ca62666f0: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0588127Z b02a7525f878: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0588951Z fcb6f6d2c998: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0589758Z e8c73c638ae9: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0590572Z 1e3d9b7d1452: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0591385Z 4aa0ea1413d3: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0592198Z 7c881f9ab25e: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0593016Z 5627a970d25e: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0593817Z 19cf2287de7f: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0594612Z ebba9ccde3ef: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0595412Z 1933f300df8c: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0596388Z 85eb50066c11: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0597315Z dc333708c31c: Pulling fs layer
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0598176Z fcb6f6d2c998: Waiting
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0598927Z e8c73c638ae9: Waiting
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0599674Z 1e3d9b7d1452: Waiting
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0600408Z 4aa0ea1413d3: Waiting
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0601165Z 7c881f9ab25e: Waiting
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0601910Z 5627a970d25e: Waiting
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0602643Z 19cf2287de7f: Waiting
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0603396Z ebba9ccde3ef: Waiting
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0604148Z 1933f300df8c: Waiting
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0604923Z 85eb50066c11: Waiting
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.0605655Z dc333708c31c: Waiting
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.4223229Z fe5ca62666f0: Verifying Checksum
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.4223934Z fe5ca62666f0: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.4270496Z 07a64a71e011: Verifying Checksum
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.4495476Z 07a64a71e011: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.4770388Z fe5ca62666f0: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.5926440Z b02a7525f878: Verifying Checksum
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.5927476Z b02a7525f878: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.7004920Z e8c73c638ae9: Verifying Checksum
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.7008380Z e8c73c638ae9: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.7427667Z fcb6f6d2c998: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.9016351Z 1e3d9b7d1452: Verifying Checksum
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.9019561Z 1e3d9b7d1452: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.9392694Z 4aa0ea1413d3: Verifying Checksum
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.9395044Z 4aa0ea1413d3: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:24.9957781Z b02a7525f878: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.0081201Z fcb6f6d2c998: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.0203772Z e8c73c638ae9: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.0301280Z 1e3d9b7d1452: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.0427440Z 4aa0ea1413d3: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.0718352Z 7c881f9ab25e: Verifying Checksum
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.0720343Z 7c881f9ab25e: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.0823537Z 7c881f9ab25e: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.2995057Z 5627a970d25e: Verifying Checksum
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.2995730Z 5627a970d25e: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.3185708Z 5627a970d25e: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.4119442Z 19cf2287de7f: Verifying Checksum
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.4121059Z 19cf2287de7f: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.5284560Z ebba9ccde3ef: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.5598094Z 19cf2287de7f: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.5989463Z ebba9ccde3ef: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.8133943Z 1933f300df8c: Verifying Checksum
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.8134586Z 1933f300df8c: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.8273859Z dc333708c31c: Verifying Checksum
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.8274524Z dc333708c31c: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.8832064Z 1933f300df8c: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.9249009Z 85eb50066c11: Verifying Checksum
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:25.9249661Z 85eb50066c11: Download complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:26.2446363Z 85eb50066c11: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:26.2567402Z dc333708c31c: Pull complete
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:26.2607303Z Digest: sha256:705e0f9dabdccb17cf6a0b754504a05fe71611d2cb11f65a49ff2b435b421b23
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:26.2622040Z Status: Downloaded newer image for gcr.io/openssf/scorecard-action:v2.3.1
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:26.2634538Z gcr.io/openssf/scorecard-action:v2.3.1
+analysis	Pull gcr.io/openssf/scorecard-action:v2.3.1	2025-09-19T08:53:26.2656572Z ##[endgroup]
+analysis	Run actions/checkout@v4	﻿2025-09-19T08:53:26.2923575Z ##[group]Run actions/checkout@v4
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2924147Z with:
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2924352Z   persist-credentials: false
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2924615Z   repository: CoderDeltaLAN/ci-matrix-starter
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2925080Z   token: ***
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2925255Z   ssh-strict: true
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2925441Z   ssh-user: git
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2925611Z   clean: true
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2925796Z   sparse-checkout-cone-mode: true
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2926034Z   fetch-depth: 1
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2926371Z   fetch-tags: false
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2926563Z   show-progress: true
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2926741Z   lfs: false
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2926908Z   submodules: false
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2927090Z   set-safe-directory: true
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.2927541Z ##[endgroup]
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4010051Z Syncing repository: CoderDeltaLAN/ci-matrix-starter
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4011650Z ##[group]Getting Git version info
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4012099Z Working directory is '/home/runner/work/ci-matrix-starter/ci-matrix-starter'
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4012907Z [command]/usr/bin/git version
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4102052Z git version 2.51.0
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4129942Z ##[endgroup]
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4147256Z Temporarily overriding HOME='/home/runner/work/_temp/d16cc105-91af-49f9-8bed-5d716b8e759b' before making global git config changes
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4148653Z Adding repository directory to the temporary git global config as a safe directory
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4163187Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/ci-matrix-starter/ci-matrix-starter
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4203567Z Deleting the contents of '/home/runner/work/ci-matrix-starter/ci-matrix-starter'
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4207231Z ##[group]Initializing the repository
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4211541Z [command]/usr/bin/git init /home/runner/work/ci-matrix-starter/ci-matrix-starter
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4322892Z hint: Using 'master' as the name for the initial branch. This default branch name
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4323936Z hint: is subject to change. To configure the initial branch name to use in all
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4324672Z hint: of your new repositories, which will suppress this warning, call:
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4325049Z hint:
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4325338Z hint: 	git config --global init.defaultBranch <name>
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4325852Z hint:
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4326581Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4327304Z hint: 'development'. The just-created branch can be renamed via this command:
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4327716Z hint:
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4328024Z hint: 	git branch -m <name>
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4328427Z hint:
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4328997Z hint: Disable this message with "git config set advice.defaultBranchName false"
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4330145Z Initialized empty Git repository in /home/runner/work/ci-matrix-starter/ci-matrix-starter/.git/
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4340531Z [command]/usr/bin/git remote add origin https://github.com/CoderDeltaLAN/ci-matrix-starter
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4377691Z ##[endgroup]
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4382403Z ##[group]Disabling automatic garbage collection
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4383014Z [command]/usr/bin/git config --local gc.auto 0
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4412025Z ##[endgroup]
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4412643Z ##[group]Setting up auth
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4420463Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4449969Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4784029Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.4813159Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.5038219Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.5080567Z ##[endgroup]
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.5088903Z ##[group]Fetching the repository
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.5089781Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +43e5312972e616133477e24b9edc9e4eee085ba1:refs/remotes/origin/main
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7668541Z From https://github.com/CoderDeltaLAN/ci-matrix-starter
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7670378Z  * [new ref]         43e5312972e616133477e24b9edc9e4eee085ba1 -> origin/main
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7701893Z ##[endgroup]
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7702888Z ##[group]Determining the checkout info
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7704705Z ##[endgroup]
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7710909Z [command]/usr/bin/git sparse-checkout disable
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7753461Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7782422Z ##[group]Checking out the ref
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7786866Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7897046Z Switched to a new branch 'main'
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7898953Z branch 'main' set up to track 'origin/main'.
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7905023Z ##[endgroup]
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7943376Z [command]/usr/bin/git log -1 --format=%H
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7966902Z 43e5312972e616133477e24b9edc9e4eee085ba1
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7978459Z ##[group]Removing auth
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.7982942Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.8013425Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.8263698Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.8288672Z http.https://github.com/.extraheader
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.8298000Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.8331362Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+analysis	Run actions/checkout@v4	2025-09-19T08:53:26.8569381Z ##[endgroup]
+analysis	Run Scorecard	﻿2025-09-19T08:53:26.8735978Z ##[group]Run ossf/scorecard-action@v2.3.1
+analysis	Run Scorecard	2025-09-19T08:53:26.8736452Z with:
+analysis	Run Scorecard	2025-09-19T08:53:26.8736624Z   results_file: results.sarif
+analysis	Run Scorecard	2025-09-19T08:53:26.8736845Z   results_format: sarif
+analysis	Run Scorecard	2025-09-19T08:53:26.8737034Z   publish_results: true
+analysis	Run Scorecard	2025-09-19T08:53:26.8737367Z   repo_token: ***
+analysis	Run Scorecard	2025-09-19T08:53:26.8737653Z   internal_publish_base_url: https://api.securityscorecards.dev
+analysis	Run Scorecard	2025-09-19T08:53:26.8738164Z   internal_default_token: ***
+analysis	Run Scorecard	2025-09-19T08:53:26.8738381Z ##[endgroup]
+analysis	Run Scorecard	2025-09-19T08:53:26.8827210Z ##[command]/usr/bin/docker run --name gcrioopenssfscorecardactionv231_e2e66c --label 5efcf4 --workdir /github/workspace --rm -e "INPUT_RESULTS_FILE" -e "INPUT_RESULTS_FORMAT" -e "INPUT_PUBLISH_RESULTS" -e "INPUT_REPO_TOKEN" -e "INPUT_INTERNAL_PUBLISH_BASE_URL" -e "INPUT_INTERNAL_DEFAULT_TOKEN" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_ENVIRONMENT" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e "ACTIONS_ID_TOKEN_REQUEST_URL" -e "ACTIONS_ID_TOKEN_REQUEST_TOKEN" -e "ACTIONS_RESULTS_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/ci-matrix-starter/ci-matrix-starter":"/github/workspace" gcr.io/openssf/scorecard-action:v2.3.1
+analysis	Run Scorecard	2025-09-19T08:53:27.1024664Z 2025/09/19 08:53:27 getting repo info from file: /github/workflow/event.json
+analysis	Run Scorecard	2025-09-19T08:53:27.1031139Z 2025/09/19 08:53:27 {
+analysis	Run Scorecard	2025-09-19T08:53:27.1033949Z "inputs": null,
+analysis	Run Scorecard	2025-09-19T08:53:27.1034342Z "ref": "refs/heads/main",
+analysis	Run Scorecard	2025-09-19T08:53:27.1034696Z "repository": {
+analysis	Run Scorecard	2025-09-19T08:53:27.1035026Z "allow_forking": true,
+analysis	Run Scorecard	2025-09-19T08:53:27.1035803Z "archive_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/{archive_format}{/ref}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1036878Z "archived": false,
+analysis	Run Scorecard	2025-09-19T08:53:27.1037597Z "assignees_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/assignees{/user}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1038755Z "blobs_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/git/blobs{/sha}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1039921Z "branches_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/branches{/branch}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1040880Z "clone_url": "https://github.com/CoderDeltaLAN/ci-matrix-starter.git",
+analysis	Run Scorecard	2025-09-19T08:53:27.1041937Z "collaborators_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/collaborators{/collaborator}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1043145Z "comments_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/comments{/number}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1044556Z "commits_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/commits{/sha}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1045685Z "compare_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/compare/{base}...{head}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1047057Z "contents_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/contents/{+path}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1048188Z "contributors_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/contributors",
+analysis	Run Scorecard	2025-09-19T08:53:27.1049359Z "created_at": "2025-09-14T20:43:38Z",
+analysis	Run Scorecard	2025-09-19T08:53:27.1049793Z "default_branch": "main",
+analysis	Run Scorecard	2025-09-19T08:53:27.1050497Z "deployments_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/deployments",
+analysis	Run Scorecard	2025-09-19T08:53:27.1052176Z "description": "Reusable GitHub Actions CI for Python/TypeScript with SBOM, CodeQL, Dependabot auto-merge, and PyPI publishing (OIDC Trusted Publisher). Always-green CI ready for DevSecOps.",
+analysis	Run Scorecard	2025-09-19T08:53:27.1053564Z "disabled": false,
+analysis	Run Scorecard	2025-09-19T08:53:27.1054228Z "downloads_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/downloads",
+analysis	Run Scorecard	2025-09-19T08:53:27.1055242Z "events_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/events",
+analysis	Run Scorecard	2025-09-19T08:53:27.1055917Z "fork": false,
+analysis	Run Scorecard	2025-09-19T08:53:27.1056407Z "forks": 0,
+analysis	Run Scorecard	2025-09-19T08:53:27.1056690Z "forks_count": 0,
+analysis	Run Scorecard	2025-09-19T08:53:27.1057266Z "forks_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/forks",
+analysis	Run Scorecard	2025-09-19T08:53:27.1058032Z "full_name": "CoderDeltaLAN/ci-matrix-starter",
+analysis	Run Scorecard	2025-09-19T08:53:27.1058873Z "git_commits_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/git/commits{/sha}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1059965Z "git_refs_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/git/refs{/sha}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1061005Z "git_tags_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/git/tags{/sha}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1061951Z "git_url": "git://github.com/CoderDeltaLAN/ci-matrix-starter.git",
+analysis	Run Scorecard	2025-09-19T08:53:27.1062551Z "has_discussions": false,
+analysis	Run Scorecard	2025-09-19T08:53:27.1062923Z "has_downloads": true,
+analysis	Run Scorecard	2025-09-19T08:53:27.1063247Z "has_issues": true,
+analysis	Run Scorecard	2025-09-19T08:53:27.1063551Z "has_pages": false,
+analysis	Run Scorecard	2025-09-19T08:53:27.1063863Z "has_projects": true,
+analysis	Run Scorecard	2025-09-19T08:53:27.1064182Z "has_wiki": true,
+analysis	Run Scorecard	2025-09-19T08:53:27.1064672Z "homepage": "https://github.com/CoderDeltaLAN/ci-matrix-starter",
+analysis	Run Scorecard	2025-09-19T08:53:27.1065485Z "hooks_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/hooks",
+analysis	Run Scorecard	2025-09-19T08:53:27.1066582Z "html_url": "https://github.com/CoderDeltaLAN/ci-matrix-starter",
+analysis	Run Scorecard	2025-09-19T08:53:27.1067128Z "id": 1056803430,
+analysis	Run Scorecard	2025-09-19T08:53:27.1067437Z "is_template": false,
+analysis	Run Scorecard	2025-09-19T08:53:27.1068179Z "issue_comment_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/issues/comments{/number}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1069430Z "issue_events_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/issues/events{/number}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1070579Z "issues_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/issues{/number}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1071525Z "keys_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/keys{/key_id}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1072424Z "labels_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/labels{/name}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1073106Z "language": "Shell",
+analysis	Run Scorecard	2025-09-19T08:53:27.1073736Z "languages_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/languages",
+analysis	Run Scorecard	2025-09-19T08:53:27.1074519Z "license": null,
+analysis	Run Scorecard	2025-09-19T08:53:27.1075121Z "merges_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/merges",
+analysis	Run Scorecard	2025-09-19T08:53:27.1076414Z "milestones_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/milestones{/number}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1077227Z "mirror_url": null,
+analysis	Run Scorecard	2025-09-19T08:53:27.1077574Z "name": "ci-matrix-starter",
+analysis	Run Scorecard	2025-09-19T08:53:27.1077957Z "node_id": "R_kgDOPv2KZg",
+analysis	Run Scorecard	2025-09-19T08:53:27.1078773Z "notifications_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/notifications{?since,all,participating}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1079852Z "open_issues": 11,
+analysis	Run Scorecard	2025-09-19T08:53:27.1080130Z "open_issues_count": 11,
+analysis	Run Scorecard	2025-09-19T08:53:27.1080417Z "owner": {
+analysis	Run Scorecard	2025-09-19T08:53:27.1080844Z "avatar_url": "https://avatars.githubusercontent.com/u/152043745?v=4",
+analysis	Run Scorecard	2025-09-19T08:53:27.1081633Z "events_url": "https://api.github.com/users/CoderDeltaLAN/events{/privacy}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1082446Z "followers_url": "https://api.github.com/users/CoderDeltaLAN/followers",
+analysis	Run Scorecard	2025-09-19T08:53:27.1083637Z "following_url": "https://api.github.com/users/CoderDeltaLAN/following{/other_user}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1084554Z "gists_url": "https://api.github.com/users/CoderDeltaLAN/gists{/gist_id}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1085155Z "gravatar_id": "",
+analysis	Run Scorecard	2025-09-19T08:53:27.1085550Z "html_url": "https://github.com/CoderDeltaLAN",
+analysis	Run Scorecard	2025-09-19T08:53:27.1085987Z "id": 152043745,
+analysis	Run Scorecard	2025-09-19T08:53:27.1086483Z "login": "CoderDeltaLAN",
+analysis	Run Scorecard	2025-09-19T08:53:27.1086835Z "node_id": "U_kgDOCRAA4Q",
+analysis	Run Scorecard	2025-09-19T08:53:27.1087373Z "organizations_url": "https://api.github.com/users/CoderDeltaLAN/orgs",
+analysis	Run Scorecard	2025-09-19T08:53:27.1088244Z "received_events_url": "https://api.github.com/users/CoderDeltaLAN/received_events",
+analysis	Run Scorecard	2025-09-19T08:53:27.1089108Z "repos_url": "https://api.github.com/users/CoderDeltaLAN/repos",
+analysis	Run Scorecard	2025-09-19T08:53:27.1089648Z "site_admin": false,
+analysis	Run Scorecard	2025-09-19T08:53:27.1090210Z "starred_url": "https://api.github.com/users/CoderDeltaLAN/starred{/owner}{/repo}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1091132Z "subscriptions_url": "https://api.github.com/users/CoderDeltaLAN/subscriptions",
+analysis	Run Scorecard	2025-09-19T08:53:27.1091766Z "type": "User",
+analysis	Run Scorecard	2025-09-19T08:53:27.1092132Z "url": "https://api.github.com/users/CoderDeltaLAN",
+analysis	Run Scorecard	2025-09-19T08:53:27.1092623Z "user_view_type": "public"
+analysis	Run Scorecard	2025-09-19T08:53:27.1093027Z },
+analysis	Run Scorecard	2025-09-19T08:53:27.1093291Z "private": false,
+analysis	Run Scorecard	2025-09-19T08:53:27.1093908Z "pulls_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/pulls{/number}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1094694Z "pushed_at": "2025-09-19T08:48:24Z",
+analysis	Run Scorecard	2025-09-19T08:53:27.1095420Z "releases_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/releases{/id}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1096158Z "size": 17494,
+analysis	Run Scorecard	2025-09-19T08:53:27.1162767Z "ssh_url": "git@github.com:CoderDeltaLAN/ci-matrix-starter.git",
+analysis	Run Scorecard	2025-09-19T08:53:27.1163482Z "stargazers_count": 1,
+analysis	Run Scorecard	2025-09-19T08:53:27.1164129Z "stargazers_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/stargazers",
+analysis	Run Scorecard	2025-09-19T08:53:27.1165182Z "statuses_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/statuses/{sha}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1166436Z "subscribers_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/subscribers",
+analysis	Run Scorecard	2025-09-19T08:53:27.1167518Z "subscription_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/subscription",
+analysis	Run Scorecard	2025-09-19T08:53:27.1168622Z "svn_url": "https://github.com/CoderDeltaLAN/ci-matrix-starter",
+analysis	Run Scorecard	2025-09-19T08:53:27.1169544Z "tags_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/tags",
+analysis	Run Scorecard	2025-09-19T08:53:27.1170450Z "teams_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/teams",
+analysis	Run Scorecard	2025-09-19T08:53:27.1171112Z "topics": [
+analysis	Run Scorecard	2025-09-19T08:53:27.1171438Z "always-green",
+analysis	Run Scorecard	2025-09-19T08:53:27.1171754Z "automation",
+analysis	Run Scorecard	2025-09-19T08:53:27.1172024Z "ci",
+analysis	Run Scorecard	2025-09-19T08:53:27.1172271Z "codeql",
+analysis	Run Scorecard	2025-09-19T08:53:27.1172515Z "cosign",
+analysis	Run Scorecard	2025-09-19T08:53:27.1172780Z "dependabot",
+analysis	Run Scorecard	2025-09-19T08:53:27.1173049Z "devsecops",
+analysis	Run Scorecard	2025-09-19T08:53:27.1173328Z "github-actions",
+analysis	Run Scorecard	2025-09-19T08:53:27.1173610Z "matrix",
+analysis	Run Scorecard	2025-09-19T08:53:27.1173877Z "node",
+analysis	Run Scorecard	2025-09-19T08:53:27.1174131Z "pnpm",
+analysis	Run Scorecard	2025-09-19T08:53:27.1174391Z "pre-commit",
+analysis	Run Scorecard	2025-09-19T08:53:27.1174671Z "pypi",
+analysis	Run Scorecard	2025-09-19T08:53:27.1174918Z "python",
+analysis	Run Scorecard	2025-09-19T08:53:27.1175200Z "reusable-workflows",
+analysis	Run Scorecard	2025-09-19T08:53:27.1175510Z "sbom",
+analysis	Run Scorecard	2025-09-19T08:53:27.1175771Z "security",
+analysis	Run Scorecard	2025-09-19T08:53:27.1176030Z "sigstore",
+analysis	Run Scorecard	2025-09-19T08:53:27.1176499Z "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:27.1176801Z "typescript"
+analysis	Run Scorecard	2025-09-19T08:53:27.1177517Z ],
+analysis	Run Scorecard	2025-09-19T08:53:27.1177985Z "trees_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/git/trees{/sha}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1178422Z "updated_at": "2025-09-19T08:48:28Z",
+analysis	Run Scorecard	2025-09-19T08:53:27.1178776Z "url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter",
+analysis	Run Scorecard	2025-09-19T08:53:27.1179132Z "visibility": "public",
+analysis	Run Scorecard	2025-09-19T08:53:27.1179336Z "watchers": 1,
+analysis	Run Scorecard	2025-09-19T08:53:27.1179526Z "watchers_count": 1,
+analysis	Run Scorecard	2025-09-19T08:53:27.1179751Z "web_commit_signoff_required": false
+analysis	Run Scorecard	2025-09-19T08:53:27.1180133Z },
+analysis	Run Scorecard	2025-09-19T08:53:27.1180279Z "sender": {
+analysis	Run Scorecard	2025-09-19T08:53:27.1180552Z "avatar_url": "https://avatars.githubusercontent.com/u/152043745?v=4",
+analysis	Run Scorecard	2025-09-19T08:53:27.1181025Z "events_url": "https://api.github.com/users/CoderDeltaLAN/events{/privacy}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1181494Z "followers_url": "https://api.github.com/users/CoderDeltaLAN/followers",
+analysis	Run Scorecard	2025-09-19T08:53:27.1181986Z "following_url": "https://api.github.com/users/CoderDeltaLAN/following{/other_user}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1182482Z "gists_url": "https://api.github.com/users/CoderDeltaLAN/gists{/gist_id}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1182815Z "gravatar_id": "",
+analysis	Run Scorecard	2025-09-19T08:53:27.1183038Z "html_url": "https://github.com/CoderDeltaLAN",
+analysis	Run Scorecard	2025-09-19T08:53:27.1183297Z "id": 152043745,
+analysis	Run Scorecard	2025-09-19T08:53:27.1183475Z "login": "CoderDeltaLAN",
+analysis	Run Scorecard	2025-09-19T08:53:27.1183671Z "node_id": "U_kgDOCRAA4Q",
+analysis	Run Scorecard	2025-09-19T08:53:27.1183984Z "organizations_url": "https://api.github.com/users/CoderDeltaLAN/orgs",
+analysis	Run Scorecard	2025-09-19T08:53:27.1184454Z "received_events_url": "https://api.github.com/users/CoderDeltaLAN/received_events",
+analysis	Run Scorecard	2025-09-19T08:53:27.1184907Z "repos_url": "https://api.github.com/users/CoderDeltaLAN/repos",
+analysis	Run Scorecard	2025-09-19T08:53:27.1185211Z "site_admin": false,
+analysis	Run Scorecard	2025-09-19T08:53:27.1185524Z "starred_url": "https://api.github.com/users/CoderDeltaLAN/starred{/owner}{/repo}",
+analysis	Run Scorecard	2025-09-19T08:53:27.1186019Z "subscriptions_url": "https://api.github.com/users/CoderDeltaLAN/subscriptions",
+analysis	Run Scorecard	2025-09-19T08:53:27.1186674Z "type": "User",
+analysis	Run Scorecard	2025-09-19T08:53:27.1186904Z "url": "https://api.github.com/users/CoderDeltaLAN",
+analysis	Run Scorecard	2025-09-19T08:53:27.1187177Z "user_view_type": "public"
+analysis	Run Scorecard	2025-09-19T08:53:27.1187376Z },
+analysis	Run Scorecard	2025-09-19T08:53:27.1187562Z "workflow": ".github/workflows/scorecards.yml"
+analysis	Run Scorecard	2025-09-19T08:53:27.1187811Z }
+analysis	Run Scorecard	2025-09-19T08:53:27.1188381Z EnvGithubAuthToken: GITHUB_AUTH_TOKEN ***
+analysis	Run Scorecard	2025-09-19T08:53:27.1188640Z Scorecard options:
+analysis	Run Scorecard	2025-09-19T08:53:27.1188822Z Ref: HEAD
+analysis	Run Scorecard	2025-09-19T08:53:27.1189008Z Repository: CoderDeltaLAN/ci-matrix-starter
+analysis	Run Scorecard	2025-09-19T08:53:27.1189266Z Local:
+analysis	Run Scorecard	2025-09-19T08:53:27.1189419Z Format: sarif
+analysis	Run Scorecard	2025-09-19T08:53:27.1189600Z Policy file: /policy.yml
+analysis	Run Scorecard	2025-09-19T08:53:27.1189733Z
+analysis	Run Scorecard	2025-09-19T08:53:27.1189819Z Event / repo information:
+analysis	Run Scorecard	2025-09-19T08:53:27.1190034Z Event file: /github/workflow/event.json
+analysis	Run Scorecard	2025-09-19T08:53:27.1190287Z Event name: workflow_dispatch
+analysis	Run Scorecard	2025-09-19T08:53:27.1190493Z Fork repository: false
+analysis	Run Scorecard	2025-09-19T08:53:27.1190691Z Private repository: false
+analysis	Run Scorecard	2025-09-19T08:53:27.1190890Z Publication enabled: false
+analysis	Run Scorecard	2025-09-19T08:53:27.1191098Z Default branch: main
+analysis	Run Scorecard	2025-09-19T08:53:39.4530417Z 2025/09/19 08:53:39 getting repo info from file: /github/workflow/event.json
+analysis	Run Scorecard	2025-09-19T08:53:39.4531105Z {
+analysis	Run Scorecard	2025-09-19T08:53:39.4532332Z    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+analysis	Run Scorecard	2025-09-19T08:53:39.4545393Z    "version": "2.1.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.4545754Z    "runs": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4546031Z       {
+analysis	Run Scorecard	2025-09-19T08:53:39.4546491Z          "automationDetails": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4547240Z             "id": "supply-chain/branch-protection/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799-19 Sep 25 08:53 +0000"
+analysis	Run Scorecard	2025-09-19T08:53:39.4548065Z          },
+analysis	Run Scorecard	2025-09-19T08:53:39.4548328Z          "tool": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4548621Z             "driver": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4548954Z                "name": "Scorecard",
+analysis	Run Scorecard	2025-09-19T08:53:39.4549469Z                "informationUri": "https://github.com/ossf/scorecard",
+analysis	Run Scorecard	2025-09-19T08:53:39.4550023Z                "semanticVersion": "v4.13.1",
+analysis	Run Scorecard	2025-09-19T08:53:39.4550620Z                "rules": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4550952Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4551275Z                      "id": "BranchProtectionID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4551753Z                      "name": "Branch-Protection",
+analysis	Run Scorecard	2025-09-19T08:53:39.4552792Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#branch-protection",
+analysis	Run Scorecard	2025-09-19T08:53:39.4553813Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4554255Z                         "text": "Branch-Protection"
+analysis	Run Scorecard	2025-09-19T08:53:39.4554868Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4555194Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4555994Z                         "text": "Determines if the default and release branches are protected with GitHub's branch protection settings."
+analysis	Run Scorecard	2025-09-19T08:53:39.4557065Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4557272Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4557878Z                         "text": "Determines if the default and release branches are protected with GitHub's branch protection settings.",
+analysis	Run Scorecard	2025-09-19T08:53:39.4558888Z 2025/09/19 08:53:39 {
+analysis	Run Scorecard	2025-09-19T08:53:39.4559221Z "inputs": null,
+analysis	Run Scorecard	2025-09-19T08:53:39.4559543Z "ref": "refs/heads/main",
+analysis	Run Scorecard	2025-09-19T08:53:39.4559885Z "repository": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4560178Z "allow_forking": true,
+analysis	Run Scorecard	2025-09-19T08:53:39.4560889Z "archive_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/{archive_format}{/ref}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4561663Z "archived": false,
+analysis	Run Scorecard	2025-09-19T08:53:39.4562320Z "assignees_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/assignees{/user}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4563393Z "blobs_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/git/blobs{/sha}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4564453Z "branches_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/branches{/branch}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4565364Z "clone_url": "https://github.com/CoderDeltaLAN/ci-matrix-starter.git",
+analysis	Run Scorecard	2025-09-19T08:53:39.4566126Z "collaborators_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/collaborators{/collaborator}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4567390Z "comments_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/comments{/number}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4568120Z "commits_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/commits{/sha}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4568822Z "compare_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/compare/{base}...{head}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4569703Z "contents_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/contents/{+path}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4570726Z "contributors_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/contributors",
+analysis	Run Scorecard	2025-09-19T08:53:39.4571453Z "created_at": "2025-09-14T20:43:38Z",
+analysis	Run Scorecard	2025-09-19T08:53:39.4571858Z "default_branch": "main",
+analysis	Run Scorecard	2025-09-19T08:53:39.4572493Z "deployments_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/deployments",
+analysis	Run Scorecard	2025-09-19T08:53:39.4573984Z "description": "Reusable GitHub Actions CI for Python/TypeScript with SBOM, CodeQL, Dependabot auto-merge, and PyPI publishing (OIDC Trusted Publisher). Always-green CI ready for DevSecOps.",
+analysis	Run Scorecard	2025-09-19T08:53:39.4575251Z "disabled": false,
+analysis	Run Scorecard	2025-09-19T08:53:39.4575708Z "downloads_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/downloads",
+analysis	Run Scorecard	2025-09-19T08:53:39.4576554Z "events_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/events",
+analysis	Run Scorecard	2025-09-19T08:53:39.4576937Z "fork": false,
+analysis	Run Scorecard	2025-09-19T08:53:39.4577150Z "forks": 0,
+analysis	Run Scorecard	2025-09-19T08:53:39.4577368Z "forks_count": 0,
+analysis	Run Scorecard	2025-09-19T08:53:39.4577676Z "forks_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/forks",
+analysis	Run Scorecard	2025-09-19T08:53:39.4578172Z "full_name": "CoderDeltaLAN/ci-matrix-starter",
+analysis	Run Scorecard	2025-09-19T08:53:39.4578625Z "git_commits_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/git/commits{/sha}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4579312Z "git_refs_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/git/refs{/sha}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4580171Z "git_tags_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/git/tags{/sha}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4580741Z "git_url": "git://github.com/CoderDeltaLAN/ci-matrix-starter.git",
+analysis	Run Scorecard	2025-09-19T08:53:39.4581061Z "has_discussions": false,
+analysis	Run Scorecard	2025-09-19T08:53:39.4581355Z "has_downloads": true,
+analysis	Run Scorecard	2025-09-19T08:53:39.4581538Z "has_issues": true,
+analysis	Run Scorecard	2025-09-19T08:53:39.4581711Z "has_pages": false,
+analysis	Run Scorecard	2025-09-19T08:53:39.4581878Z "has_projects": true,
+analysis	Run Scorecard	2025-09-19T08:53:39.4582295Z "has_wiki": true,
+analysis	Run Scorecard	2025-09-19T08:53:39.4582560Z "homepage": "https://github.com/CoderDeltaLAN/ci-matrix-starter",
+analysis	Run Scorecard	2025-09-19T08:53:39.4583106Z "hooks_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/hooks",
+analysis	Run Scorecard	2025-09-19T08:53:39.4583547Z "html_url": "https://github.com/CoderDeltaLAN/ci-matrix-starter",
+analysis	Run Scorecard	2025-09-19T08:53:39.4583941Z "id": 1056803430,
+analysis	Run Scorecard	2025-09-19T08:53:39.4584114Z "is_template": false,
+analysis	Run Scorecard	2025-09-19T08:53:39.4584610Z "issue_comment_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/issues/comments{/number}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4585360Z "issue_events_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/issues/events{/number}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4585996Z "issues_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/issues{/number}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4586855Z "keys_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/keys{/key_id}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4587520Z "labels_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/labels{/name}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4588035Z "language": "Shell",
+analysis	Run Scorecard	2025-09-19T08:53:39.4588374Z "languages_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/languages",
+analysis	Run Scorecard	2025-09-19T08:53:39.4588748Z "license": null,
+analysis	Run Scorecard	2025-09-19T08:53:39.4589054Z "merges_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/merges",
+analysis	Run Scorecard	2025-09-19T08:53:39.4589610Z "milestones_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/milestones{/number}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4590037Z "mirror_url": null,
+analysis	Run Scorecard	2025-09-19T08:53:39.4590217Z "name": "ci-matrix-starter",
+analysis	Run Scorecard	2025-09-19T08:53:39.4590427Z "node_id": "R_kgDOPv2KZg",
+analysis	Run Scorecard	2025-09-19T08:53:39.4590908Z "notifications_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/notifications{?since,all,participating}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4591424Z "open_issues": 11,
+analysis	Run Scorecard	2025-09-19T08:53:39.4591607Z "open_issues_count": 11,
+analysis	Run Scorecard	2025-09-19T08:53:39.4591784Z "owner": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4592050Z "avatar_url": "https://avatars.githubusercontent.com/u/152043745?v=4",
+analysis	Run Scorecard	2025-09-19T08:53:39.4592488Z "events_url": "https://api.github.com/users/CoderDeltaLAN/events{/privacy}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4592927Z "followers_url": "https://api.github.com/users/CoderDeltaLAN/followers",
+analysis	Run Scorecard	2025-09-19T08:53:39.4593387Z "following_url": "https://api.github.com/users/CoderDeltaLAN/following{/other_user}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4593857Z "gists_url": "https://api.github.com/users/CoderDeltaLAN/gists{/gist_id}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4594183Z "gravatar_id": "",
+analysis	Run Scorecard	2025-09-19T08:53:39.4594390Z "html_url": "https://github.com/CoderDeltaLAN",
+analysis	Run Scorecard	2025-09-19T08:53:39.4594641Z "id": 152043745,
+analysis	Run Scorecard	2025-09-19T08:53:39.4594808Z "login": "CoderDeltaLAN",
+analysis	Run Scorecard	2025-09-19T08:53:39.4595006Z "node_id": "U_kgDOCRAA4Q",
+analysis	Run Scorecard	2025-09-19T08:53:39.4595300Z "organizations_url": "https://api.github.com/users/CoderDeltaLAN/orgs",
+analysis	Run Scorecard	2025-09-19T08:53:39.4595766Z "received_events_url": "https://api.github.com/users/CoderDeltaLAN/received_events",
+analysis	Run Scorecard	2025-09-19T08:53:39.4596400Z "repos_url": "https://api.github.com/users/CoderDeltaLAN/repos",
+analysis	Run Scorecard	2025-09-19T08:53:39.4596749Z "site_admin": false,
+analysis	Run Scorecard	2025-09-19T08:53:39.4597076Z "starred_url": "https://api.github.com/users/CoderDeltaLAN/starred{/owner}{/repo}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4597578Z "subscriptions_url": "https://api.github.com/users/CoderDeltaLAN/subscriptions",
+analysis	Run Scorecard	2025-09-19T08:53:39.4597933Z "type": "User",
+analysis	Run Scorecard	2025-09-19T08:53:39.4598137Z "url": "https://api.github.com/users/CoderDeltaLAN",
+analysis	Run Scorecard	2025-09-19T08:53:39.4598405Z "user_view_type": "public"
+analysis	Run Scorecard	2025-09-19T08:53:39.4598738Z },
+analysis	Run Scorecard	2025-09-19T08:53:39.4598891Z "private": false,
+analysis	Run Scorecard	2025-09-19T08:53:39.4599227Z "pulls_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/pulls{/number}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4599630Z "pushed_at": "2025-09-19T08:48:24Z",
+analysis	Run Scorecard	2025-09-19T08:53:39.4600022Z "releases_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/releases{/id}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4600406Z "size": 17494,
+analysis	Run Scorecard	2025-09-19T08:53:39.4600646Z "ssh_url": "git@github.com:CoderDeltaLAN/ci-matrix-starter.git",
+analysis	Run Scorecard	2025-09-19T08:53:39.4601044Z "stargazers_count": 1,
+analysis	Run Scorecard	2025-09-19T08:53:39.4601397Z "stargazers_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/stargazers",
+analysis	Run Scorecard	2025-09-19T08:53:39.4601954Z "statuses_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/statuses/{sha}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4602526Z "subscribers_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/subscribers",
+analysis	Run Scorecard	2025-09-19T08:53:39.4603116Z "subscription_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/subscription",
+analysis	Run Scorecard	2025-09-19T08:53:39.4603598Z "svn_url": "https://github.com/CoderDeltaLAN/ci-matrix-starter",
+analysis	Run Scorecard	2025-09-19T08:53:39.4604010Z "tags_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/tags",
+analysis	Run Scorecard	2025-09-19T08:53:39.4604474Z "teams_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/teams",
+analysis	Run Scorecard	2025-09-19T08:53:39.4604820Z "topics": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4604970Z "always-green",
+analysis	Run Scorecard	2025-09-19T08:53:39.4605134Z "automation",
+analysis	Run Scorecard	2025-09-19T08:53:39.4605295Z "ci",
+analysis	Run Scorecard	2025-09-19T08:53:39.4605434Z "codeql",
+analysis	Run Scorecard	2025-09-19T08:53:39.4605577Z "cosign",
+analysis	Run Scorecard	2025-09-19T08:53:39.4605717Z "dependabot",
+analysis	Run Scorecard	2025-09-19T08:53:39.4605954Z "devsecops",
+analysis	Run Scorecard	2025-09-19T08:53:39.4606115Z "github-actions",
+analysis	Run Scorecard	2025-09-19T08:53:39.4606501Z "matrix",
+analysis	Run Scorecard	2025-09-19T08:53:39.4606651Z "node",
+analysis	Run Scorecard	2025-09-19T08:53:39.4606793Z "pnpm",
+analysis	Run Scorecard	2025-09-19T08:53:39.4606937Z "pre-commit",
+analysis	Run Scorecard	2025-09-19T08:53:39.4607085Z "pypi",
+analysis	Run Scorecard	2025-09-19T08:53:39.4607226Z "python",
+analysis	Run Scorecard	2025-09-19T08:53:39.4607376Z "reusable-workflows",
+analysis	Run Scorecard	2025-09-19T08:53:39.4607562Z "sbom",
+analysis	Run Scorecard	2025-09-19T08:53:39.4607700Z "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.4607852Z "sigstore",
+analysis	Run Scorecard	2025-09-19T08:53:39.4608002Z "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.4608161Z "typescript"
+analysis	Run Scorecard	2025-09-19T08:53:39.4608310Z ],
+analysis	Run Scorecard	2025-09-19T08:53:39.4608650Z "trees_url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/git/trees{/sha}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4609122Z "updated_at": "2025-09-19T08:48:28Z",
+analysis	Run Scorecard	2025-09-19T08:53:39.4609431Z "url": "https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter",
+analysis	Run Scorecard	2025-09-19T08:53:39.4609749Z "visibility": "public",
+analysis	Run Scorecard	2025-09-19T08:53:39.4609925Z "watchers": 1,
+analysis	Run Scorecard	2025-09-19T08:53:39.4610091Z "watchers_count": 1,
+analysis	Run Scorecard	2025-09-19T08:53:39.4610275Z "web_commit_signoff_required": false
+analysis	Run Scorecard	2025-09-19T08:53:39.4610484Z },
+analysis	Run Scorecard	2025-09-19T08:53:39.4610620Z "sender": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4610869Z "avatar_url": "https://avatars.githubusercontent.com/u/152043745?v=4",
+analysis	Run Scorecard	2025-09-19T08:53:39.4611300Z "events_url": "https://api.github.com/users/CoderDeltaLAN/events{/privacy}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4611739Z "followers_url": "https://api.github.com/users/CoderDeltaLAN/followers",
+analysis	Run Scorecard	2025-09-19T08:53:39.4612195Z "following_url": "https://api.github.com/users/CoderDeltaLAN/following{/other_user}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4612648Z "gists_url": "https://api.github.com/users/CoderDeltaLAN/gists{/gist_id}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4612967Z "gravatar_id": "",
+analysis	Run Scorecard	2025-09-19T08:53:39.4613168Z "html_url": "https://github.com/CoderDeltaLAN",
+analysis	Run Scorecard	2025-09-19T08:53:39.4613416Z "id": 152043745,
+analysis	Run Scorecard	2025-09-19T08:53:39.4613595Z "login": "CoderDeltaLAN",
+analysis	Run Scorecard	2025-09-19T08:53:39.4613788Z "node_id": "U_kgDOCRAA4Q",
+analysis	Run Scorecard	2025-09-19T08:53:39.4614084Z "organizations_url": "https://api.github.com/users/CoderDeltaLAN/orgs",
+analysis	Run Scorecard	2025-09-19T08:53:39.4614539Z "received_events_url": "https://api.github.com/users/CoderDeltaLAN/received_events",
+analysis	Run Scorecard	2025-09-19T08:53:39.4614970Z "repos_url": "https://api.github.com/users/CoderDeltaLAN/repos",
+analysis	Run Scorecard	2025-09-19T08:53:39.4615252Z "site_admin": false,
+analysis	Run Scorecard	2025-09-19T08:53:39.4615578Z "starred_url": "https://api.github.com/users/CoderDeltaLAN/starred{/owner}{/repo}",
+analysis	Run Scorecard	2025-09-19T08:53:39.4616508Z "subscriptions_url": "https://api.github.com/users/CoderDeltaLAN/subscriptions",
+analysis	Run Scorecard	2025-09-19T08:53:39.4616860Z "type": "User",
+analysis	Run Scorecard	2025-09-19T08:53:39.4617069Z "url": "https://api.github.com/users/CoderDeltaLAN",
+analysis	Run Scorecard	2025-09-19T08:53:39.4617335Z "user_view_type": "public"
+analysis	Run Scorecard	2025-09-19T08:53:39.4617641Z },
+analysis	Run Scorecard	2025-09-19T08:53:39.4617822Z "workflow": ".github/workflows/scorecards.yml"
+analysis	Run Scorecard	2025-09-19T08:53:39.4618058Z }
+analysis	Run Scorecard	2025-09-19T08:53:39.4639066Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Enable branch protection settings in your source hosting provider to avoid force pushes or deletion of your important branches.\n\n- For GitHub, check out the steps [here](https://docs.github.com/en/github/administering-a-repository/managing-a-branch-protection-rule).\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nRisk: `High` (vulnerable to intentional malicious code injection)\n\n\n\nThis check determines whether a project's default and release branches are\n\nprotected with GitHub's [branch protection](https://docs.github.com/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) \n\nor [repository rules](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) settings.\n\nBranch protection allows maintainers to define rules that enforce\n\ncertain workflows for branches, such as requiring review or passing certain\n\nstatus checks before acceptance into a main branch, or preventing rewriting of\n\npublic history.\n\n\n\nNote: The following settings queried by the Branch-Protection check require an admin token: `DismissStaleReviews`, `EnforceAdmins`, `RequireLastPushApproval`, `RequiresStatusChecks` and `UpToDateBeforeMerge`. If\n\nthe provided token does not have admin access, the check will query the branch\n\nsettings accessible to non-admins and provide results based only on these settings.\n\nHowever, all of these settings are accessible via Repo Rules. `EnforceAdmins` is calculated slightly differently.\n\nThis setting is calculated as `false` if any [Bypass Actors](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository#granting-bypass-permissions-for-your-ruleset)\n\n are defined on any rule, regardless of if they are admins.\n\n\n\nDifferent types of branch protection protect against different risks:\n\n\n\n  - Require code review: \n\n    - requires at least one reviewer, which greatly\n\n    reduces the risk that a compromised contributor can inject malicious code.\n\n    Review also increases the likelihood that an unintentional vulnerability in\n\n    a contribution will be detected and fixed before the change is accepted.\n\n\n\n    - requiring two or more reviewers protects even more from the insider risk \n\n    whereby a compromised contributor can be used by an attacker to LGTM \n\n    the attacker PR and inject a malicious code as if it was legit.\n\n\n\n  - Prevent force push: prevents use of the `--force` command on public\n\n    branches, which overwrites code irrevocably. This protection prevents the\n\n    rewriting of public history without external notice.\n\n\n\n  - Require [status checks](https://docs.github.com/en/github/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks):\n\n    ensures that all required CI tests are met before a change is accepted.\n\n\n\nAlthough requiring code review can greatly reduce the chance that\n\nunintentional or malicious code enters the \"main\" branch, it is not feasible for\n\nall projects, such as those that don't have many active participants. For more\n\ndiscussion, see [Code Reviews](https://github.com/ossf/scorecard/blob/main/docs/checks.md#code-review).\n\n\n\nAdditionally, in some cases these rules will need to be suspended. For example,\n\nif a past commit includes illegal content such as child pornography, it may be\n\nnecessary to use a force push to rewrite the history rather than simply hide the\n\ncommit.\n\n\n\nThis test has tiered scoring. Each tier must be fully satisfied to achieve points at the next tier. For example, if you fulfill the Tier 3 checks but do not fulfill all the Tier 2 checks, you will not receive any points for Tier 3.\n\n\n\nNote: If Scorecard is run without an administrative access token, the requirements that specify “For administrators” can be safely ignored, and scores will be determined as if all such requirements have been met.\n\n\n\nTier 1 Requirements (3/10 points):\n\n  - Prevent force push\n\n  - Prevent branch deletion\n\n\n\nTier 2 Requirements (6/10 points):\n\n  - Require at least 1 reviewer for approval before merging\n\n  - For administrators: Require branch to be up to date before merging\n\n  - For administrators: Require approval of the most recent reviewable push\n\n\n\nTier 3 Requirements (8/10 points):\n\n  - Require branch to pass at least 1 status check before merging\n\n\n\nTier 4 Requirements (9/10 points):\n\n  - Require at least 2 reviewers for approval before merging\n\n  - Require review from code owners\n\n\n\nTier 5 Requirements (10/10 points):\n\n  - For administrators: Dismiss stale reviews and approvals when new commits are pushed\n\n  - For administrators: Include administrator for review\n\n\n\nGitLab Integration Status:\n\n  - GitLab associates releases with commits and not with the branch. Releases are ignored in this portion of the scoring.\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.4655707Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4655918Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4656294Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.4656579Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4656766Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4656997Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.4657244Z                         "problem.severity": "error",
+analysis	Run Scorecard	2025-09-19T08:53:39.4657517Z                         "security-severity": "7.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.4657753Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4657970Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.4658202Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.4658422Z                            "source-code",
+analysis	Run Scorecard	2025-09-19T08:53:39.4658648Z                            "code-reviews"
+analysis	Run Scorecard	2025-09-19T08:53:39.4658856Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4659033Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4659198Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4659355Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4659507Z             }
+analysis	Run Scorecard	2025-09-19T08:53:39.4659659Z          },
+analysis	Run Scorecard	2025-09-19T08:53:39.4659812Z          "results": []
+analysis	Run Scorecard	2025-09-19T08:53:39.4659982Z       },
+analysis	Run Scorecard	2025-09-19T08:53:39.4660122Z       {
+analysis	Run Scorecard	2025-09-19T08:53:39.4660281Z          "automationDetails": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4660672Z             "id": "supply-chain/local/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799-19 Sep 25 08:53 +0000"
+analysis	Run Scorecard	2025-09-19T08:53:39.4661073Z          },
+analysis	Run Scorecard	2025-09-19T08:53:39.4661220Z          "tool": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4661379Z             "driver": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4661569Z                "name": "Scorecard",
+analysis	Run Scorecard	2025-09-19T08:53:39.4661854Z                "informationUri": "https://github.com/ossf/scorecard",
+analysis	Run Scorecard	2025-09-19T08:53:39.4662161Z                "semanticVersion": "v4.13.1",
+analysis	Run Scorecard	2025-09-19T08:53:39.4662386Z                "rules": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4662564Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4662747Z                      "id": "BinaryArtifactsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4663004Z                      "name": "Binary-Artifacts",
+analysis	Run Scorecard	2025-09-19T08:53:39.4663578Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#binary-artifacts",
+analysis	Run Scorecard	2025-09-19T08:53:39.4664144Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4664391Z                         "text": "Binary-Artifacts"
+analysis	Run Scorecard	2025-09-19T08:53:39.4664620Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4664940Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4665371Z                         "text": "Determines if the project has generated executable (binary) artifacts in the source repository."
+analysis	Run Scorecard	2025-09-19T08:53:39.4665802Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4665981Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4666497Z                         "text": "Determines if the project has generated executable (binary) artifacts in the source repository.",
+analysis	Run Scorecard	2025-09-19T08:53:39.4674432Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Remove the generated executable artifacts from the repository.\n\n- Build from source.\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nRisk: `High` (non-reviewable code)\n\n\n\nThis check determines whether the project has generated executable (binary)\n\nartifacts in the source repository.\n\n\n\nIncluding generated executables in the source repository increases user risk.\n\nMany programming language systems can generate executables from source code\n\n(e.g., C/C++ generated machine code, Java `.class` files, Python `.pyc` files,\n\nand minified JavaScript). Users will often directly use executables if they are\n\nincluded in the source repository, leading to many dangerous behaviors.\n\n\n\nProblems with generated executable (binary) artifacts:\n\n\n\n  - Binary artifacts cannot be reviewed, allowing possible obsolete or\n\n    maliciously subverted executables. Reviews generally review source code, not\n\n    executables, since it's difficult to audit executables to ensure that they\n\n    correspond to the source code. Over time the included executables might not\n\n    correspond to the source code.\n\n  - Generated executables allow the executable generation process to atrophy,\n\n    which can lead to an inability to create working executables. These problems\n\n    can be countered with verified reproducible builds, but it's easier to\n\n    implement verified reproducible builds when executables are not included in\n\n    the source repository (since the executable generation process is less\n\n    likely to have atrophied).\n\n\n\nAllowed by Scorecard:\n\n\n\n  - Files in the source repository that are simultaneously reviewable source\n\n    code and executables, since these are reviewable. (Some interpretive\n\n    systems, such as many operating system shells, don't have a mechanism for\n\n    storing generated executables that are different from the source file.)\n\n  - Source code in the source repository generated by other tools (e.g., by\n\n    bison, yacc, flex, and lex). There are potential downsides to generated\n\n    source code, but generated source code tends to be much easier to review and\n\n    thus presents a lower risk. Generated source code is also often difficult\n\n    for external tools to detect.\n\n  - Generated documentation in source repositories. Generated documentation is\n\n    intended for use by humans (not computers) who can evaluate the context.\n\n    Thus, generated documentation doesn't pose the same level of risk.\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.4682555Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4682755Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4682998Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.4683211Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4683385Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4683611Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.4683851Z                         "problem.severity": "error",
+analysis	Run Scorecard	2025-09-19T08:53:39.4684119Z                         "security-severity": "7.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.4684354Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4684570Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.4684791Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.4685012Z                            "dependencies"
+analysis	Run Scorecard	2025-09-19T08:53:39.4685228Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4685402Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4685571Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.4685854Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4686041Z                      "id": "DangerousWorkflowID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4686401Z                      "name": "Dangerous-Workflow",
+analysis	Run Scorecard	2025-09-19T08:53:39.4686991Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#dangerous-workflow",
+analysis	Run Scorecard	2025-09-19T08:53:39.4687569Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4687816Z                         "text": "Dangerous-Workflow"
+analysis	Run Scorecard	2025-09-19T08:53:39.4688161Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4688340Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4688715Z                         "text": "Determines if the project's GitHub Action workflows avoid dangerous patterns."
+analysis	Run Scorecard	2025-09-19T08:53:39.4689072Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4689249Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4689580Z                         "text": "Determines if the project's GitHub Action workflows avoid dangerous patterns.",
+analysis	Run Scorecard	2025-09-19T08:53:39.4696951Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Avoid the dangerous workflow patterns. See this [post](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) for information on avoiding untrusted code checkouts. See this [document](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) for information on avoiding and mitigating the risk of script injections.\n\n\n\n**Severity**: Critical\n\n\n\n**Details**:\n\nRisk: `Critical`  (vulnerable to repository compromise)\n\n\n\nThis check determines whether the project's GitHub Action workflows has dangerous\n\ncode patterns. Some examples of these patterns are untrusted code checkouts,\n\nlogging github context and secrets, or use of potentially untrusted inputs in scripts.\n\nThe following patterns are checked:\n\n\n\nUntrusted Code Checkout: This is the misuse of potentially dangerous triggers.\n\nThis checks if a `pull_request_target` or `workflow_run` workflow trigger was used in conjunction\n\nwith an explicit pull request checkout. Workflows triggered with `pull_request_target` / `workflow_run`\n\nhave write permission to the target repository and access to target repository\n\nsecrets. With the PR checkout, PR authors may compromise the repository, for\n\nexample, by using build scripts controlled by the author of the PR or reading\n\ntoken in memory. This check does not detect whether untrusted code checkouts are\n\nused safely, for example, only on pull request that have been assigned a label.\n\n\n\nScript Injection with Untrusted Context Variables: This pattern detects whether a\n\nworkflow's inline script may execute untrusted input from attackers. This occurs when\n\nan attacker adds malicious commands and scripts to a context. When a workflow runs,\n\nthese strings may be interpreted as code that is executed on the runner. Attackers\n\ncan add their own content to certain github context variables that are considered\n\nuntrusted, for example, `github.event.issue.title`. These values should not flow\n\ndirectly into executable code.\n\n\n\nThe highest score is awarded when all workflows avoid the dangerous code patterns.\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.4704180Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4704367Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4704610Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.4704817Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4705002Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4705231Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.4705475Z                         "problem.severity": "error",
+analysis	Run Scorecard	2025-09-19T08:53:39.4705737Z                         "security-severity": "9.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.4705969Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4706269Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.4706499Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.4706844Z                            "infrastructure"
+analysis	Run Scorecard	2025-09-19T08:53:39.4707061Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4707239Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4707404Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.4707559Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4707747Z                      "id": "DependencyUpdateToolID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4708011Z                      "name": "Dependency-Update-Tool",
+analysis	Run Scorecard	2025-09-19T08:53:39.4708624Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#dependency-update-tool",
+analysis	Run Scorecard	2025-09-19T08:53:39.4709367Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4709633Z                         "text": "Dependency-Update-Tool"
+analysis	Run Scorecard	2025-09-19T08:53:39.4709886Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4710092Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4710406Z                         "text": "Determines if the project uses a dependency update tool."
+analysis	Run Scorecard	2025-09-19T08:53:39.4710728Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4710898Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4711189Z                         "text": "Determines if the project uses a dependency update tool.",
+analysis	Run Scorecard	2025-09-19T08:53:39.4718106Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Signup for automatic dependency updates with one of the previously listed dependency update tools and place the config file in the locations that are recommended by these tools. Due to https://github.com/dependabot/dependabot-core/issues/2804 Dependabot can be enabled for forks where security updates have ever been turned on so projects maintaining stable forks should evaluate whether this behavior is satisfactory before turning it on.\n\n- Unlike Dependabot, Renovate bot has support to migrate dockerfiles' dependencies from version pinning to hash pinning via the [pinDigests setting](https://docs.renovatebot.com/configuration-options/#pindigests) without additional manual effort.\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nRisk: `High` (possibly vulnerable to attacks on known flaws)\n\n\n\nThis check tries to determine if the project uses a dependency update tool,\n\nspecifically one of:\n\n- [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates)\n\n- [Renovate bot](https://docs.renovatebot.com/configuration-options/)\n\n- [Sonatype Lift](https://help.sonatype.com/lift/getting-started)\n\n- [PyUp](https://docs.pyup.io/docs) (Python)\n\nOut-of-date dependencies make a project vulnerable to known flaws and prone to attacks.\n\nThese tools automate the process of updating dependencies by scanning for\n\noutdated or insecure requirements, and opening a pull request to update them if\n\nfound.\n\n\n\nThis check can determine only whether the dependency update tool is enabled; it\n\ndoes not ensure that the tool is run or that the tool's pull requests are\n\nmerged.\n\n\n\nNote: A project that fulfills this criterion with other tools may still receive\n\na low score on this test. There are many ways to implement dependency updates,\n\nand it is challenging for an automated tool like Scorecard to detect them all. A\n\nlow score is therefore not a definitive indication that the project is at risk.\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.4724967Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4725165Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4725404Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.4725622Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4725795Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4726016Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.4726350Z                         "problem.severity": "error",
+analysis	Run Scorecard	2025-09-19T08:53:39.4726609Z                         "security-severity": "7.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.4726846Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4727055Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.4727398Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.4727611Z                            "dependencies"
+analysis	Run Scorecard	2025-09-19T08:53:39.4727825Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4727999Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4728162Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.4728315Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4728483Z                      "id": "LicenseID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4728700Z                      "name": "License",
+analysis	Run Scorecard	2025-09-19T08:53:39.4729318Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#license",
+analysis	Run Scorecard	2025-09-19T08:53:39.4729845Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4730073Z                         "text": "License"
+analysis	Run Scorecard	2025-09-19T08:53:39.4730283Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4730461Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4730751Z                         "text": "Determines if the project has defined a license."
+analysis	Run Scorecard	2025-09-19T08:53:39.4731040Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4731215Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4731478Z                         "text": "Determines if the project has defined a license.",
+analysis	Run Scorecard	2025-09-19T08:53:39.4739362Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Determine [which license](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) to apply to your project. For GitHub hosted projects, follow those instructions to establish a license for your project.\n\n- For other hosting environments, create the license in a `.adoc`, `.asc`, `.docx`, `.doc`, `.ext`, `.html`, `.markdown`, `.md`, `.rst`, `.txt`, or `.xml`, named `LICENSE`, `COPYRIGHT`, or `COPYING`, and place it in the top-level directory. To identify a specific license, use an [SPDX license identifier](https://spdx.org/licenses/) in the filename. Examples include `LICENSE.md`, `Apache-2.0-LICENSE.md` or `LICENSE-Apache-2.0`.\n\n- Alternately, create a `LICENSE` directory and add a license file(s) with a name that matches your [SPDX license identifier](https://spdx.org/licenses/). such as `LICENSES/Apache-2.0.txt`.\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nRisk: `Low` (possible impediment to security review)\n\n\n\nThis check tries to determine if the project has published a license. It\n\nworks by using either hosting APIs or by checking standard locations\n\nfor a file named according to common conventions for licenses.\n\n\n\nA license can give users information about how the source code may or may\n\nnot be used. The lack of a license will impede any kind of security review\n\nor audit and creates a legal risk for potential users.\n\n\n\nScorecard uses the\n\n[GitHub License API](https://docs.github.com/en/rest/licenses#get-the-license-for-a-repository)\n\nfor GitHub hosted projects. Otherwise, Scorecard uses its own heuristics to\n\ndetect a published license file.\n\n\n\nOn its own, this check will detect files in the top-level directory with\n\nany combination of the following names and extensions:`LICENSE`, `LICENCE`,\n\n`COPYING`, `COPYRIGHT` and having common extensions such as `.html`, `.txt`,\n\nor `.md`. It will also detect these files in a directory named `LICENSES`.\n\n(Files in a `LICENSES` directory are typically named as their\n\n[SPDX](https://spdx.org/licenses/) license identifier followed by an\n\nappropriate file extension, as described in the [REUSE](https://reuse.software/spec/) Specification.)\n\n\n\nLicense Requirements:\n\n  - A detected `LICENSE`, `COPYRIGHT`, or `COPYING` filename (6/10 points)\n\n  - The detected file is at the top-level directory (3/10 points)\n\n  - A [FSF or OSI](https://spdx.org/licenses/) license is specified (1/10 points)\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.4747234Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4747434Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4747674Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.4748006Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4748180Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4748407Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.4748673Z                         "problem.severity": "recommendation",
+analysis	Run Scorecard	2025-09-19T08:53:39.4748946Z                         "security-severity": "1.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.4749186Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4749387Z                            "license"
+analysis	Run Scorecard	2025-09-19T08:53:39.4749698Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4749871Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4750040Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.4750197Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4750385Z                      "id": "PinnedDependenciesID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4750649Z                      "name": "Pinned-Dependencies",
+analysis	Run Scorecard	2025-09-19T08:53:39.4751240Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#pinned-dependencies",
+analysis	Run Scorecard	2025-09-19T08:53:39.4751837Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4752087Z                         "text": "Pinned-Dependencies"
+analysis	Run Scorecard	2025-09-19T08:53:39.4752327Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4752507Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4752920Z                         "text": "Determines if the project has declared and pinned the dependencies of its build process."
+analysis	Run Scorecard	2025-09-19T08:53:39.4753324Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4753500Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4753883Z                         "text": "Determines if the project has declared and pinned the dependencies of its build process.",
+analysis	Run Scorecard	2025-09-19T08:53:39.4768036Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- If your project is producing an application, declare all your dependencies with specific versions in your package format file (e.g. `package.json` for npm, `requirements.txt` for python, `packages.config` for nuget). For C/C++, check in the code from a trusted source and add a `README` on the specific version used (and the archive SHA hashes).\n\n- If your project is producing an application and the package manager supports lock files (e.g. `package-lock.json` for npm), make sure to check these in the source code as well. These files maintain signatures for the entire dependency tree and saves from future exploitation in case the package is compromised.\n\n- For Dockerfiles used in building and releasing your project, pin dependencies by hash. See [Dockerfile](https://github.com/ossf/scorecard/blob/main/cron/internal/worker/Dockerfile) for example. If you are using a manifest list to support builds across multiple architectures, you can pin to the manifest list hash instead of a single image hash. You can use a tool like [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to obtain the hash of the manifest list like in this [example](https://github.com/ossf/scorecard/issues/1773#issuecomment-1076699039).\n\n- For GitHub workflows used in building and releasing your project, pin dependencies by hash. See [main.yaml](https://github.com/ossf/scorecard/blob/f55b86d6627cc3717e3a0395e03305e81b9a09be/.github/workflows/main.yml#L27) for example. To determine the permissions needed for your workflows, you may use [StepSecurity's online tool](https://app.stepsecurity.io/secureworkflow/) by ticking the \"Pin actions to a full length commit SHA\". You may also tick the \"Restrict permissions for GITHUB_TOKEN\" to fix issues found by the Token-Permissions check.\n\n- To help update your dependencies after pinning them, use tools such as those listed for the dependency update tool check.\n\n\n\n**Severity**: Medium\n\n\n\n**Details**:\n\nRisk: `Medium` (possible compromised dependencies)\n\n\n\nThis check tries to determine if the project pins dependencies used during its build and release process.\n\nA \"pinned dependency\" is a dependency that is explicitly set to a specific hash instead of\n\nallowing a mutable version or range of versions. It\n\nis currently limited to repositories hosted on GitHub, and does not support\n\nother source hosting repositories (i.e., Forges).\n\n\n\nThe check works by looking for unpinned dependencies in Dockerfiles, shell scripts, and GitHub workflows\n\nwhich are used during the build and release process of a project.\n\nSpecial considerations for Go modules treat full semantic versions as pinned\n\ndue to how the Go tool verifies downloaded content against the hashes when anyone first downloaded the module.\n\n\n\nPinned dependencies reduce several security risks:\n\n\n\n  - They ensure that checking and deployment are all done with the same\n\n    software, reducing deployment risks, simplifying debugging, and enabling\n\n    reproducibility.\n\n  - They can help mitigate compromised dependencies from undermining the\n\n    security of the project (in the case where you've evaluated the pinned\n\n    dependency, you are confident it's not compromised, and a later version is\n\n    released that is compromised).\n\n  - They are one way to [counter dependency confusion (aka substitution) attacks](https://azure.microsoft.com/en-us/resources/3-ways-to-mitigate-risk-using-private-package-feeds/),\n\n    in which an application uses multiple feeds to acquire software packages (a\n\n    \"hybrid configuration\"), and attackers fool the user into using a malicious\n\n    package via a feed that was not expected for that package.\n\n\n\nHowever, pinning dependencies can inhibit software updates, either because of a\n\nsecurity vulnerability or because the pinned version is compromised. Mitigate\n\nthis risk by:\n\n\n\n  - using automated tools to notify applications when their dependencies are\n\n    outdated;\n\n  - quickly updating applications that do pin dependencies.\n\n\n\nFor projects hosted on GitHub, you can learn more about\n\ndependencies using the [GitHub dependency graph](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph).\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.4782121Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4782323Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4782574Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.4782785Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4782970Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4783193Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.4783445Z                         "problem.severity": "warning",
+analysis	Run Scorecard	2025-09-19T08:53:39.4783712Z                         "security-severity": "4.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.4783959Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4784170Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.4784404Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.4784632Z                            "dependencies"
+analysis	Run Scorecard	2025-09-19T08:53:39.4784850Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4785038Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4785204Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.4785370Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4785554Z                      "id": "TokenPermissionsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4785818Z                      "name": "Token-Permissions",
+analysis	Run Scorecard	2025-09-19T08:53:39.4786496Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#token-permissions",
+analysis	Run Scorecard	2025-09-19T08:53:39.4787081Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4787338Z                         "text": "Token-Permissions"
+analysis	Run Scorecard	2025-09-19T08:53:39.4787566Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4787755Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4788142Z                         "text": "Determines if the project's workflows follow the principle of least privilege."
+analysis	Run Scorecard	2025-09-19T08:53:39.4788511Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4788681Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4789034Z                         "text": "Determines if the project's workflows follow the principle of least privilege.",
+analysis	Run Scorecard	2025-09-19T08:53:39.4800001Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Set top-level permissions as `read-all` or `contents: read` as described in GitHub's [documentation](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions).\n\n- Set any required write permissions at the job-level. Only set the permissions required for that job; do not set `permissions: write-all` at the job level.\n\n- To help determine the permissions needed for your workflows, you may use [StepSecurity's online tool](https://app.stepsecurity.io/secureworkflow/) by ticking the \"Restrict permissions for GITHUB_TOKEN\". You may also tick the \"Pin actions to a full length commit SHA\" to fix issues found by the Pinned-dependencies check.\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nRisk: `High` (vulnerable to malicious code additions)\n\n\n\nThis check determines whether the project's automated workflows tokens follow the\n\nprinciple of least privilege. This is important because attackers may use a\n\ncompromised token with write access to, for example, push malicious code into the\n\nproject.\n\n\n\nIt is currently limited to repositories hosted on GitHub, and does not support\n\nother source hosting repositories (i.e., Forges).\n\n\n\nThe highest score is awarded when the permissions definitions in each workflow's\n\nyaml file are set as read-only at the\n\n[top level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions)\n\nand the required write permissions are declared at the\n\n[run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions).\n\nOne point is reduced from the score if all jobs have their permissions defined but the top level permissions are not defined.\n\nThis configuration is secure, but there is a chance that when a new job is added to the workflow, its job permissions could be\n\nleft undefined because of human error.\n\n\n\nThough a project's score won't be penalized, the check's details will include\n\nwarnings for more sensitive run-level permissions, listed below:\n\n\n\n* `actions` - May allow an attacker to steal GitHub secrets by approving to run an action that needs approval.\n\n* `checks` - May allow an attacker to remove pre-submit checks and introduce a bug.\n\n* `contents` - Allows an attacker to commit unreviewed code. However, points are not reduced if the job utilizes a recognized packaging action or command.\n\n* `deployments` - May allow an attacker to charge repo owner by triggering VM runs, and tiny chance an attacker can trigger a remote service with code they own if server accepts code/location variables unsanitized.\n\n* `packages` - Allows an attacker to publish packages. However, points are not reduced if the job utilizes a recognized packaging action or command.\n\n* `security-events` - May allow an attacker to read vulnerability reports before a patch is available. However, points are not reduced if the job utilizes a recognized action for uploading SARIF results.\n\n* `statuses` - May allow an attacker to change the result of pre-submit checks and get a PR merged.\n\n\n\nThis compromise makes it clear the maintainer has done what's possible to use those permissions safety,\n\nbut allows users to identify that the permissions are used.\n\n\n\nThe check cannot detect if the \"read-only\" GitHub permission setting is\n\nenabled, as there is no API available.\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.4810916Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4811116Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4811357Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.4811571Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4811750Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4811978Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.4812230Z                         "problem.severity": "error",
+analysis	Run Scorecard	2025-09-19T08:53:39.4812636Z                         "security-severity": "7.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.4812878Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4813087Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.4813317Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.4813540Z                            "infrastructure"
+analysis	Run Scorecard	2025-09-19T08:53:39.4813763Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4813933Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4814102Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4814259Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4814522Z             }
+analysis	Run Scorecard	2025-09-19T08:53:39.4814673Z          },
+analysis	Run Scorecard	2025-09-19T08:53:39.4814819Z          "results": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4814988Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.4815167Z                "ruleId": "DependencyUpdateToolID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4815425Z                "ruleIndex": 2,
+analysis	Run Scorecard	2025-09-19T08:53:39.4815619Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4817922Z                   "text": "score is 0: no update tool detected:\nWarn: tool 'RenovateBot' is not used: Follow the instructions from https://docs.renovatebot.com/configuration-options/. (Low effort)\nWarn: tool 'Dependabot' is not used: Follow the instructions from https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates. (Low effort)\nWarn: tool 'PyUp' is not used: Follow the instructions from https://docs.pyup.io/docs. (Low effort)\nWarn: tool 'Sonatype Lift' is not used: Follow the instructions from https://help.sonatype.com/lift/getting-started. (Low effort)\nClick Remediation section below to solve this issue"
+analysis	Run Scorecard	2025-09-19T08:53:39.4820131Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.4820301Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4820488Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4820719Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4820953Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4821177Z                            "startLine": 1
+analysis	Run Scorecard	2025-09-19T08:53:39.4821393Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.4821607Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4821872Z                            "uri": "no file associated with this alert",
+analysis	Run Scorecard	2025-09-19T08:53:39.4822160Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.4822400Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.4822575Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4822746Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4822899Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4823056Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.4823202Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.4823376Z                "ruleId": "LicenseID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4823595Z                "ruleIndex": 3,
+analysis	Run Scorecard	2025-09-19T08:53:39.4823792Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4824158Z                   "text": "score is 0: license file not detected\nClick Remediation section below to solve this issue"
+analysis	Run Scorecard	2025-09-19T08:53:39.4824557Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.4824725Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4824911Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4825093Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4825319Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4825542Z                            "startLine": 1
+analysis	Run Scorecard	2025-09-19T08:53:39.4825755Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.4825957Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4826315Z                            "uri": "no file associated with this alert",
+analysis	Run Scorecard	2025-09-19T08:53:39.4826595Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.4826840Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.4827022Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4827194Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4827348Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4827503Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.4827652Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.4827834Z                "ruleId": "TokenPermissionsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4828077Z                "ruleIndex": 5,
+analysis	Run Scorecard	2025-09-19T08:53:39.4828277Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4830299Z                   "text": "score is 0: topLevel 'security-events' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/build.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead.\nClick Remediation section below for further remediation help"
+analysis	Run Scorecard	2025-09-19T08:53:39.4832301Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.4832473Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4832659Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4832842Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4833080Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4833296Z                            "startLine": 10,
+analysis	Run Scorecard	2025-09-19T08:53:39.4833529Z                            "endLine": 10,
+analysis	Run Scorecard	2025-09-19T08:53:39.4833760Z                            "snippet": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4833988Z                               "text": "write"
+analysis	Run Scorecard	2025-09-19T08:53:39.4834206Z                            }
+analysis	Run Scorecard	2025-09-19T08:53:39.4834396Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.4834590Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4834856Z                            "uri": ".github/workflows/build.yml",
+analysis	Run Scorecard	2025-09-19T08:53:39.4835133Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.4835363Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.4835556Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4835740Z                      "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4837509Z                         "text": "topLevel 'security-events' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/build.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead."
+analysis	Run Scorecard	2025-09-19T08:53:39.4839193Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4839356Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4839515Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4839669Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.4839824Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.4840001Z                "ruleId": "TokenPermissionsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4840246Z                "ruleIndex": 5,
+analysis	Run Scorecard	2025-09-19T08:53:39.4840445Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4842343Z                   "text": "score is 0: topLevel 'security-events' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/codeql.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead.\nClick Remediation section below for further remediation help"
+analysis	Run Scorecard	2025-09-19T08:53:39.4844256Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.4844420Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4844609Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4844782Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4845015Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4845230Z                            "startLine": 13,
+analysis	Run Scorecard	2025-09-19T08:53:39.4845457Z                            "endLine": 13,
+analysis	Run Scorecard	2025-09-19T08:53:39.4845684Z                            "snippet": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4845902Z                               "text": "write"
+analysis	Run Scorecard	2025-09-19T08:53:39.4846122Z                            }
+analysis	Run Scorecard	2025-09-19T08:53:39.4846405Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.4846605Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4846867Z                            "uri": ".github/workflows/codeql.yml",
+analysis	Run Scorecard	2025-09-19T08:53:39.4847249Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.4847481Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.4847656Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4847837Z                      "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4849500Z                         "text": "topLevel 'security-events' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/codeql.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead."
+analysis	Run Scorecard	2025-09-19T08:53:39.4851282Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4851451Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4851603Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4851761Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.4851913Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.4852088Z                "ruleId": "TokenPermissionsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4852333Z                "ruleIndex": 5,
+analysis	Run Scorecard	2025-09-19T08:53:39.4852523Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4854454Z                   "text": "score is 0: topLevel 'contents' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/dependabot-auto-merge.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead.\nClick Remediation section below for further remediation help"
+analysis	Run Scorecard	2025-09-19T08:53:39.4856504Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.4856667Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4856856Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4857027Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4857260Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4857470Z                            "startLine": 11,
+analysis	Run Scorecard	2025-09-19T08:53:39.4857695Z                            "endLine": 11,
+analysis	Run Scorecard	2025-09-19T08:53:39.4857912Z                            "snippet": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4858140Z                               "text": "write"
+analysis	Run Scorecard	2025-09-19T08:53:39.4858359Z                            }
+analysis	Run Scorecard	2025-09-19T08:53:39.4858540Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.4858741Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4859030Z                            "uri": ".github/workflows/dependabot-auto-merge.yml",
+analysis	Run Scorecard	2025-09-19T08:53:39.4859335Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.4859559Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.4859738Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4859913Z                      "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4861625Z                         "text": "topLevel 'contents' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/dependabot-auto-merge.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead."
+analysis	Run Scorecard	2025-09-19T08:53:39.4863348Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4863512Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4863673Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4863823Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.4863973Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.4864150Z                "ruleId": "TokenPermissionsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4864387Z                "ruleIndex": 5,
+analysis	Run Scorecard	2025-09-19T08:53:39.4864586Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4866561Z                   "text": "score is 0: topLevel 'packages' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/ghcr-publish.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead.\nClick Remediation section below for further remediation help"
+analysis	Run Scorecard	2025-09-19T08:53:39.4868595Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.4868764Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4869047Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4869225Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4869450Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4869665Z                            "startLine": 8,
+analysis	Run Scorecard	2025-09-19T08:53:39.4869881Z                            "endLine": 8,
+analysis	Run Scorecard	2025-09-19T08:53:39.4870104Z                            "snippet": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4870328Z                               "text": "write"
+analysis	Run Scorecard	2025-09-19T08:53:39.4870543Z                            }
+analysis	Run Scorecard	2025-09-19T08:53:39.4870734Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.4870928Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4871200Z                            "uri": ".github/workflows/ghcr-publish.yml",
+analysis	Run Scorecard	2025-09-19T08:53:39.4871473Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.4871705Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.4871879Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4872060Z                      "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4873730Z                         "text": "topLevel 'packages' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/ghcr-publish.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead."
+analysis	Run Scorecard	2025-09-19T08:53:39.4875415Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4875589Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4875740Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4875895Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.4876040Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.4876346Z                "ruleId": "TokenPermissionsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4876593Z                "ruleIndex": 5,
+analysis	Run Scorecard	2025-09-19T08:53:39.4876786Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4878652Z                   "text": "score is 0: topLevel 'packages' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/npm-gpr.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead.\nClick Remediation section below for further remediation help"
+analysis	Run Scorecard	2025-09-19T08:53:39.4880538Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.4880704Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4880896Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4881070Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4881303Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4881516Z                            "startLine": 8,
+analysis	Run Scorecard	2025-09-19T08:53:39.4881741Z                            "endLine": 8,
+analysis	Run Scorecard	2025-09-19T08:53:39.4881962Z                            "snippet": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4882192Z                               "text": "write"
+analysis	Run Scorecard	2025-09-19T08:53:39.4882414Z                            }
+analysis	Run Scorecard	2025-09-19T08:53:39.4882598Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.4882800Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4883059Z                            "uri": ".github/workflows/npm-gpr.yml",
+analysis	Run Scorecard	2025-09-19T08:53:39.4883334Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.4883562Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.4883877Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4884055Z                      "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4885698Z                         "text": "topLevel 'packages' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/npm-gpr.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead."
+analysis	Run Scorecard	2025-09-19T08:53:39.4887557Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4887722Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4887880Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4888031Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.4888199Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.4888375Z                "ruleId": "TokenPermissionsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4888620Z                "ruleIndex": 5,
+analysis	Run Scorecard	2025-09-19T08:53:39.4888819Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4890719Z                   "text": "score is 0: topLevel 'contents' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/release-drafter.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead.\nClick Remediation section below for further remediation help"
+analysis	Run Scorecard	2025-09-19T08:53:39.4892637Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.4892806Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4892990Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4893171Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4893398Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4893620Z                            "startLine": 10,
+analysis	Run Scorecard	2025-09-19T08:53:39.4893847Z                            "endLine": 10,
+analysis	Run Scorecard	2025-09-19T08:53:39.4894079Z                            "snippet": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4894298Z                               "text": "write"
+analysis	Run Scorecard	2025-09-19T08:53:39.4894523Z                            }
+analysis	Run Scorecard	2025-09-19T08:53:39.4894713Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.4894908Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4895180Z                            "uri": ".github/workflows/release-drafter.yml",
+analysis	Run Scorecard	2025-09-19T08:53:39.4895461Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.4895706Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.4895878Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4896059Z                      "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4897822Z                         "text": "topLevel 'contents' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/release-drafter.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead."
+analysis	Run Scorecard	2025-09-19T08:53:39.4899518Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4899685Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4899835Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4899990Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.4900134Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.4900314Z                "ruleId": "TokenPermissionsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4900559Z                "ruleIndex": 5,
+analysis	Run Scorecard	2025-09-19T08:53:39.4900753Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4902636Z                   "text": "score is 0: topLevel 'contents' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/release-sbom.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead.\nClick Remediation section below for further remediation help"
+analysis	Run Scorecard	2025-09-19T08:53:39.4904777Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.4904943Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4905136Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4905308Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4905546Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4905868Z                            "startLine": 7,
+analysis	Run Scorecard	2025-09-19T08:53:39.4906095Z                            "endLine": 7,
+analysis	Run Scorecard	2025-09-19T08:53:39.4906410Z                            "snippet": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4906634Z                               "text": "write"
+analysis	Run Scorecard	2025-09-19T08:53:39.4906850Z                            }
+analysis	Run Scorecard	2025-09-19T08:53:39.4907038Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.4907235Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4907497Z                            "uri": ".github/workflows/release-sbom.yml",
+analysis	Run Scorecard	2025-09-19T08:53:39.4907783Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.4908009Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.4908186Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4908360Z                      "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4910061Z                         "text": "topLevel 'contents' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/release-sbom.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead."
+analysis	Run Scorecard	2025-09-19T08:53:39.4911742Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4911903Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4912063Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4912217Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.4912372Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.4912546Z                "ruleId": "TokenPermissionsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4912793Z                "ruleIndex": 5,
+analysis	Run Scorecard	2025-09-19T08:53:39.4912990Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4914869Z                   "text": "score is 0: topLevel 'statuses' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/semantic-pr.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead.\nClick Remediation section below for further remediation help"
+analysis	Run Scorecard	2025-09-19T08:53:39.4917137Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.4917331Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4917532Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4917722Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4917954Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4918175Z                            "startLine": 7,
+analysis	Run Scorecard	2025-09-19T08:53:39.4918397Z                            "endLine": 7,
+analysis	Run Scorecard	2025-09-19T08:53:39.4918625Z                            "snippet": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4918852Z                               "text": "write"
+analysis	Run Scorecard	2025-09-19T08:53:39.4919080Z                            }
+analysis	Run Scorecard	2025-09-19T08:53:39.4919271Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.4919472Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4919743Z                            "uri": ".github/workflows/semantic-pr.yml",
+analysis	Run Scorecard	2025-09-19T08:53:39.4920019Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.4920254Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.4920429Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4920605Z                      "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4922274Z                         "text": "topLevel 'statuses' permission set to 'write'\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/semantic-pr.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead."
+analysis	Run Scorecard	2025-09-19T08:53:39.4924075Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4924242Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4924497Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4924652Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.4924797Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.4924978Z                "ruleId": "TokenPermissionsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4925221Z                "ruleIndex": 5,
+analysis	Run Scorecard	2025-09-19T08:53:39.4925420Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4927392Z                   "text": "score is 0: no topLevel permission defined\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/supply-chain.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead.\nClick Remediation section below for further remediation help"
+analysis	Run Scorecard	2025-09-19T08:53:39.4929263Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.4929429Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4929625Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4929801Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4930032Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4930241Z                            "startLine": 1,
+analysis	Run Scorecard	2025-09-19T08:53:39.4930464Z                            "endLine": 1
+analysis	Run Scorecard	2025-09-19T08:53:39.4930674Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.4930876Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4931143Z                            "uri": ".github/workflows/supply-chain.yml",
+analysis	Run Scorecard	2025-09-19T08:53:39.4931431Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.4931666Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.4931838Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4932017Z                      "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4933651Z                         "text": "no topLevel permission defined\nRemediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/supply-chain.yml/main?enable=permissions).\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead."
+analysis	Run Scorecard	2025-09-19T08:53:39.4935293Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4935461Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4935614Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4935774Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.4935933Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.4936110Z                "ruleId": "TokenPermissionsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4936443Z                "ruleIndex": 5,
+analysis	Run Scorecard	2025-09-19T08:53:39.4954368Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4955184Z                   "text": "score is 0: jobLevel 'contents' permission set to 'write'\nRemediation tip: Verify which permissions are needed and consider whether you can reduce them.\nClick Remediation section below for further remediation help"
+analysis	Run Scorecard	2025-09-19T08:53:39.4955984Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.4956316Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4956515Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4956706Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4956937Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4957162Z                            "startLine": 12,
+analysis	Run Scorecard	2025-09-19T08:53:39.4957388Z                            "endLine": 12,
+analysis	Run Scorecard	2025-09-19T08:53:39.4957620Z                            "snippet": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4958046Z                               "text": "write"
+analysis	Run Scorecard	2025-09-19T08:53:39.4958273Z                            }
+analysis	Run Scorecard	2025-09-19T08:53:39.4958462Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.4958658Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4958928Z                            "uri": ".github/workflows/supply-chain.yml",
+analysis	Run Scorecard	2025-09-19T08:53:39.4959213Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.4959454Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.4959632Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4959966Z                      "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4960527Z                         "text": "jobLevel 'contents' permission set to 'write'\nRemediation tip: Verify which permissions are needed and consider whether you can reduce them."
+analysis	Run Scorecard	2025-09-19T08:53:39.4961105Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4961276Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.4961430Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4961586Z             }
+analysis	Run Scorecard	2025-09-19T08:53:39.4961736Z          ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4961880Z       },
+analysis	Run Scorecard	2025-09-19T08:53:39.4962021Z       {
+analysis	Run Scorecard	2025-09-19T08:53:39.4962178Z          "automationDetails": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4962578Z             "id": "supply-chain/online-scm/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799-19 Sep 25 08:53 +0000"
+analysis	Run Scorecard	2025-09-19T08:53:39.4962988Z          },
+analysis	Run Scorecard	2025-09-19T08:53:39.4963132Z          "tool": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4963298Z             "driver": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4963478Z                "name": "Scorecard",
+analysis	Run Scorecard	2025-09-19T08:53:39.4963778Z                "informationUri": "https://github.com/ossf/scorecard",
+analysis	Run Scorecard	2025-09-19T08:53:39.4964095Z                "semanticVersion": "v4.13.1",
+analysis	Run Scorecard	2025-09-19T08:53:39.4964321Z                "rules": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4964502Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4964669Z                      "id": "CITestsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4964905Z                      "name": "CI-Tests",
+analysis	Run Scorecard	2025-09-19T08:53:39.4965411Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#ci-tests",
+analysis	Run Scorecard	2025-09-19T08:53:39.4965942Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4966296Z                         "text": "CI-Tests"
+analysis	Run Scorecard	2025-09-19T08:53:39.4966512Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4966699Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4967042Z                         "text": "Determines if the project runs tests before pull requests are merged."
+analysis	Run Scorecard	2025-09-19T08:53:39.4967385Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4967563Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4967882Z                         "text": "Determines if the project runs tests before pull requests are merged.",
+analysis	Run Scorecard	2025-09-19T08:53:39.4973149Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Check-in scripts that run all the tests in your repository.\n\n- Integrate those scripts with a CI/CD platform that runs it on every pull request (e.g. if hosted on GitHub, [GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/introduction-to-github-actions), [Prow](https://github.com/kubernetes/test-infra/tree/master/prow), etc).\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nRisk: `Low` (possible unknown vulnerabilities)\n\n\n\nThis check tries to determine if the project runs tests before pull requests are\n\nmerged. It is currently limited to repositories hosted on GitHub, and does not\n\nsupport other source hosting repositories (i.e., Forges).\n\n\n\nRunning tests helps developers catch mistakes early on, which can reduce the\n\nnumber of vulnerabilities that find their way into a project.\n\n\n\nThe check works by looking for a set of CI-system names in GitHub `CheckRuns`\n\nand `Statuses` among the recent commits (~30). A CI-system is considered\n\nwell-known if its name contains any of the following: appveyor, buildkite,\n\ncircleci, e2e, github-actions, jenkins, mergeable, test, travis-ci.\n\n\n\nNote: A project that fulfills this criterion with other tools may still receive\n\na low score on this test. There are many ways to implement CI testing, and it is\n\nchallenging for an automated tool like Scorecard to detect them all. A low score\n\nis therefore not a definitive indication that the project is at risk.\n\n\n\nIf a project's system was not detected and you think it should be, please\n\n[open an issue in the scorecard project](https://github.com/ossf/scorecard/issues/new/choose).\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.4978590Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4978791Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4979141Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.4979356Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4979533Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4979759Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.4980014Z                         "problem.severity": "recommendation",
+analysis	Run Scorecard	2025-09-19T08:53:39.4980290Z                         "security-severity": "1.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.4980527Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4980747Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.4980969Z                            "testing"
+analysis	Run Scorecard	2025-09-19T08:53:39.4981166Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.4981344Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.4981509Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.4981672Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.4981852Z                      "id": "CIIBestPracticesID",
+analysis	Run Scorecard	2025-09-19T08:53:39.4982114Z                      "name": "CII-Best-Practices",
+analysis	Run Scorecard	2025-09-19T08:53:39.4982702Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#cii-best-practices",
+analysis	Run Scorecard	2025-09-19T08:53:39.4983275Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4983525Z                         "text": "CII-Best-Practices"
+analysis	Run Scorecard	2025-09-19T08:53:39.4983755Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4983945Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4984308Z                         "text": "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge."
+analysis	Run Scorecard	2025-09-19T08:53:39.4984676Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4984846Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4985184Z                         "text": "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.",
+analysis	Run Scorecard	2025-09-19T08:53:39.4991270Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Sign up for the [OpenSSF Best Practices program](https://www.bestpractices.dev/).\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nRisk: `Low` (possibly not following security best practices)\n\n\n\nThis check determines whether the project has earned an [OpenSSF (formerly CII) Best Practices Badge](https://www.bestpractices.dev/) at the passing, silver, or gold level.\n\nThe OpenSSF Best Practices badge indicates whether or not that the project uses a set of security-focused best development practices for open\n\nsource software. The check uses the URL for the Git repo and the OpenSSF Best Practices badge API.\n\n\n\nThe OpenSSF Best Practices badge has 3 tiers: passing, silver, and gold. We give\n\nfull credit to projects that meet the [gold criteria](https://www.bestpractices.dev/criteria/2), which is a significant achievement for projects and requires multiple developers in the project.\n\nLower scores represent a project that has met the silver criteria, met the passing criteria, or is working to achieve the passing badge, with increasingly more points awarded as more criteria are met. Note that even meeting the passing criteria is a significant achievement.\n\n\n\n- [gold badge](https://www.bestpractices.dev/criteria/2): 10\n\n- [silver badge](https://www.bestpractices.dev/criteria/1): 7\n\n- [passing badge](https://www.bestpractices.dev/criteria/0): 5\n\n- in progress badge: 2\n\n\n\nSome of these criteria overlap with other Scorecard checks.\n\nHowever, note that in those overlapping cases, Scorecard can only report what it can automatically detect, while the OpenSSF Best Practices badge can report on claims and claim justifications from people (this counters false negatives and positives but has the challenge of requiring additional work from people).\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.4997261Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4997457Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4997694Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.4997907Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.4998085Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.4998426Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.4998677Z                         "problem.severity": "recommendation",
+analysis	Run Scorecard	2025-09-19T08:53:39.4998946Z                         "security-severity": "1.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.4999186Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.4999404Z                            "security-awareness",
+analysis	Run Scorecard	2025-09-19T08:53:39.4999650Z                            "security-training",
+analysis	Run Scorecard	2025-09-19T08:53:39.4999878Z                            "security"
+analysis	Run Scorecard	2025-09-19T08:53:39.5000086Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5000258Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5000427Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.5000584Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5000765Z                      "id": "CodeReviewID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5000992Z                      "name": "Code-Review",
+analysis	Run Scorecard	2025-09-19T08:53:39.5001524Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#code-review",
+analysis	Run Scorecard	2025-09-19T08:53:39.5002067Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5002301Z                         "text": "Code-Review"
+analysis	Run Scorecard	2025-09-19T08:53:39.5002521Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5002704Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5003175Z                         "text": "Determines if the project requires human code review before pull requests (aka merge requests) are merged."
+analysis	Run Scorecard	2025-09-19T08:53:39.5003630Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5003809Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5004227Z                         "text": "Determines if the project requires human code review before pull requests (aka merge requests) are merged.",
+analysis	Run Scorecard	2025-09-19T08:53:39.5016684Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- If the project has only one contributor, or does not have enough reviewers to practically require that all contributions be reviewed, try to recruit more maintainers to the project who will be willing to review others' work. Ideally at least some of these people will be from different organizations (see [Contributors](checks.md#contributors)). If the project has very limited utility, consider expanding its intended utility so more people will be interested in improving it, and make that larger scope clear to potential contributors.\n\n- Follow security best practices by performing strict code reviews for every new pull request / merge request.\n\n- Make \"code reviews\" mandatory in your repository configuration. ([Instructions for GitHub.](https://docs.github.com/en/github/administering-a-repository/about-protected-branches#require-pull-request-reviews-before-merging))\n\n- Enforce the rule for administrators / code owners as well. ([Instructions for GitHub.](https://docs.github.com/en/github/administering-a-repository/about-protected-branches#include-administrators))\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nRisk: `High` (unintentional vulnerabilities or possible injection of malicious\n\ncode)\n\n\n\nThis check determines whether the project requires human code review\n\nbefore pull requests (merge requests) are merged.\n\n\n\nReviews detect various unintentional problems, including vulnerabilities that\n\ncan be fixed immediately before they are merged, which improves the quality of\n\nthe code. Reviews may also detect or deter an attacker trying to insert\n\nmalicious code (either as a malicious contributor or as an attacker who has\n\nsubverted a contributor's account), because a reviewer might detect the\n\nsubversion.\n\n\n\nThe check determines whether the most recent changes (over the last ~30 commits) have \n\nan approval on GitHub\n\nor if the merger is different from the committer (implicit review). It also\n\nperforms a similar check for reviews using\n\n[Prow](https://github.com/kubernetes/test-infra/tree/master/prow#readme) (labels\n\n\"lgtm\" or \"approved\") and [Gerrit](https://www.gerritcodereview.com/) (\"Reviewed-on\" and \"Reviewed-by\").\n\nIf recent changes are solely bot activity (e.g. Dependabot, Renovate bot, or custom bots),\n\nthe check returns inconclusively.\n\n\n\nScoring is leveled instead of proportional to make the check more predictable.\n\nIf any bot-originated changes are unreviewed, 3 points are deducted. If any human\n\nchanges are unreviewed, 7 points are deducted if a single change is unreviewed, and\n\nanother 3 are deducted if multiple changes are unreviewed.\n\n\n\nReview by bots, including bots powered by\n\nartificial intelligence / machine learning (AI/ML),\n\ndo not count as code review.\n\nSuch reviews do not provide confidence that there will\n\nbe a second person who understands the\n\ncode change (e.g., if the originator suddenly becomes unavailable).\n\nHowever, analysis by bots\n\nmay be able to meet (at least in part) the [SAST](#sast) criterion.\n\n\n\nNote: Requiring reviews for all changes is infeasible for some projects, such as\n\nthose with only one active participant. Even a project with multiple active\n\ncontributors may not have enough active participation to be able to require\n\nreview of all proposed changes. Projects with a small number of active\n\nparticipants instead sometimes aim for a review of a\n\npercentage of proposals (e.g., \"at least half of all proposed changes are\n\nreviewed\").\n\n\n\nRequiring review does not eliminate all risks. The other reviewers might fail to\n\nnotice unintentional vulnerabilities or malicious code, be colluding with a\n\nmalicious developer, or even be the same person (using a \"[sock\n\npuppet](https://en.wikipedia.org/wiki/Sock_puppet_account)\" account).\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.5029364Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5029566Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5029808Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.5030020Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5030211Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5030442Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.5030690Z                         "problem.severity": "error",
+analysis	Run Scorecard	2025-09-19T08:53:39.5030952Z                         "security-severity": "7.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.5031184Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5031400Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.5031626Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.5031849Z                            "source-code",
+analysis	Run Scorecard	2025-09-19T08:53:39.5032068Z                            "code-reviews"
+analysis	Run Scorecard	2025-09-19T08:53:39.5032290Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5032470Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5032628Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.5032783Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5032956Z                      "id": "ContributorsID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5033189Z                      "name": "Contributors",
+analysis	Run Scorecard	2025-09-19T08:53:39.5033720Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#contributors",
+analysis	Run Scorecard	2025-09-19T08:53:39.5034268Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5034500Z                         "text": "Contributors"
+analysis	Run Scorecard	2025-09-19T08:53:39.5034717Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5034902Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5035322Z                         "text": "Determines if the project has a set of contributors from multiple organizations (e.g., companies)."
+analysis	Run Scorecard	2025-09-19T08:53:39.5035740Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5036058Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5036689Z                         "text": "Determines if the project has a set of contributors from multiple organizations (e.g., companies).",
+analysis	Run Scorecard	2025-09-19T08:53:39.5041704Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Ask contributors to [join their respective organizations](https://docs.github.com/en/organizations/managing-membership-in-your-organization/inviting-users-to-join-your-organization), if they have not already. Otherwise, there is no remediation for this check; it simply provides insight into which organizations have contributed so that you can make a trust-based decision based on that information.\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nRisk: `Low` (lower number of trusted code reviewers)\n\n\n\nThis check tries to determine if the project has recent contributors from\n\nmultiple organizations (e.g., companies). It is currently limited to\n\nrepositories hosted on GitHub, and does not support other source hosting\n\nrepositories (i.e., Forges).\n\n\n\nThe check looks at the `Company` field on the GitHub user profile for authors of\n\nrecent commits. To receive the highest score, the project must have had\n\ncontributors from at least 3 different companies in the last 30 commits; each of\n\nthose contributors must have had at least 5 commits in the last 30 commits.\n\n\n\nNote: Some projects cannot meet this requirement, such as small projects with\n\nonly one active participant, or projects with a narrow scope that cannot attract\n\nthe interest of multiple organizations. See\n\n[Code Reviews](https://github.com/ossf/scorecard/blob/main/docs/checks.md#code-review)\n\nfor more information about evaluating projects with a small number of\n\nparticipants.\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.5046884Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5047077Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5047316Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.5047530Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5047710Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5047937Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.5048188Z                         "problem.severity": "recommendation",
+analysis	Run Scorecard	2025-09-19T08:53:39.5048459Z                         "security-severity": "1.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.5048694Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5048904Z                            "source-code"
+analysis	Run Scorecard	2025-09-19T08:53:39.5049115Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5049295Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5049455Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.5049615Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5049780Z                      "id": "FuzzingID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5050002Z                      "name": "Fuzzing",
+analysis	Run Scorecard	2025-09-19T08:53:39.5050505Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#fuzzing",
+analysis	Run Scorecard	2025-09-19T08:53:39.5051015Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5051255Z                         "text": "Fuzzing"
+analysis	Run Scorecard	2025-09-19T08:53:39.5051462Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5051647Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5051900Z                         "text": "Determines if the project uses fuzzing."
+analysis	Run Scorecard	2025-09-19T08:53:39.5052162Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5052335Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5052565Z                         "text": "Determines if the project uses fuzzing.",
+analysis	Run Scorecard	2025-09-19T08:53:39.5059007Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Integrate the project with OSS-Fuzz by following the instructions [here](https://google.github.io/oss-fuzz/).\n\n\n\n**Severity**: Medium\n\n\n\n**Details**:\n\nRisk: `Medium` (possible vulnerabilities in code)\n\n\n\nThis check tries to determine if the project uses\n\n[fuzzing](https://owasp.org/www-community/Fuzzing) by checking:\n\n1. if the repository name is included in the [OSS-Fuzz](https://github.com/google/oss-fuzz) project list;\n\n2. if [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/) is deployed in the repository;\n\n3. if there are user-defined language-specified fuzzing functions in the repository.\n\n   - currently only supports [Go fuzzing](https://go.dev/doc/fuzz/),\n\n   - a limited set of property-based testing libraries for Haskell including [QuickCheck](https://hackage.haskell.org/package/QuickCheck), [Hedgehog](https://hedgehog.qa/), [validity](https://hackage.haskell.org/package/validity) or [SmallCheck](https://hackage.haskell.org/package/smallcheck),\n\n   - a limited set of property-based testing libraries for JavaScript and TypeScript including [fast-check](https://fast-check.dev/).\n\n4. if it contains a [OneFuzz](https://github.com/microsoft/onefuzz) integration [detection file](https://github.com/microsoft/onefuzz/blob/main/docs/getting-started.md#detecting-the-use-of-onefuzz);\n\n\n\nFuzzing, or fuzz testing, is the practice of feeding unexpected or random data\n\ninto a program to expose bugs. Regular fuzzing is important to detect\n\nvulnerabilities that may be exploited by others, especially since attackers can\n\nalso use fuzzing to find the same flaws.\n\n\n\nNote: A project that fulfills this criterion with other tools may still receive\n\na low score on this test. There are many ways to implement fuzzing, and it is\n\nchallenging for an automated tool like Scorecard to detect them all. A low score\n\nis therefore not a definitive indication that the project is at risk.\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.5065565Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5065767Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5066004Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.5066309Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5066491Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5066710Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.5066956Z                         "problem.severity": "warning",
+analysis	Run Scorecard	2025-09-19T08:53:39.5067221Z                         "security-severity": "4.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.5067455Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5067662Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.5067888Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.5068094Z                            "testing"
+analysis	Run Scorecard	2025-09-19T08:53:39.5068298Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5068473Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5068633Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.5068800Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5068968Z                      "id": "MaintainedID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5069195Z                      "name": "Maintained",
+analysis	Run Scorecard	2025-09-19T08:53:39.5069712Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#maintained",
+analysis	Run Scorecard	2025-09-19T08:53:39.5070246Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5070473Z                         "text": "Maintained"
+analysis	Run Scorecard	2025-09-19T08:53:39.5070695Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5070880Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5071180Z                         "text": "Determines if the project is \"actively maintained\"."
+analysis	Run Scorecard	2025-09-19T08:53:39.5071479Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5071647Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5071915Z                         "text": "Determines if the project is \"actively maintained\".",
+analysis	Run Scorecard	2025-09-19T08:53:39.5077211Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- There is no remediation work needed from projects with a low score; this check simply provides insight into the project activity and maintenance commitment. External users should determine whether the software is the type that would not normally need active maintenance.\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nRisk: `High` (possibly unpatched vulnerabilities)\n\n\n\nThis check determines whether the project is actively maintained. If the project\n\nis archived, it receives the lowest score. If there is at least one commit per\n\nweek during the previous 90 days, the project receives the highest score.  If there\n\nis activity on issues from users who are collaborators, members, or owners of the\n\nproject, the project receives a partial score.\n\n\n\nA project which is not active might not be patched, have its\n\ndependencies patched, or be actively tested and used. However, a lack\n\nof active maintenance is not necessarily always a problem. Some software,\n\nespecially smaller utility functions, does not normally need to be maintained.\n\nFor example, a library that determines if an integer is even would not normally\n\nneed maintenance unless an underlying implementation language definition\n\nchanged. A lack of active maintenance should signal that potential users should\n\ninvestigate further to judge the situation.\n\n\n\nThis check will only succeed if a Github project is \u003e90 days old. Projects\n\nthat are younger than this are too new to assess whether they are maintained\n\nor not, and users should inspect the contents of those projects to ensure they\n\nare as expected.\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.5082646Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5082835Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5083075Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.5083285Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5083461Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5083683Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.5083924Z                         "problem.severity": "error",
+analysis	Run Scorecard	2025-09-19T08:53:39.5084178Z                         "security-severity": "7.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.5084408Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5084621Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.5084840Z                            "security"
+analysis	Run Scorecard	2025-09-19T08:53:39.5085048Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5085220Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5085391Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.5085551Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5085720Z                      "id": "PackagingID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5085950Z                      "name": "Packaging",
+analysis	Run Scorecard	2025-09-19T08:53:39.5086574Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#packaging",
+analysis	Run Scorecard	2025-09-19T08:53:39.5087100Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5087330Z                         "text": "Packaging"
+analysis	Run Scorecard	2025-09-19T08:53:39.5087554Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5087733Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5088234Z                         "text": "Determines if the project is published as a package that others can easily download, install, easily update, and uninstall."
+analysis	Run Scorecard	2025-09-19T08:53:39.5088725Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5088891Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5089363Z                         "text": "Determines if the project is published as a package that others can easily download, install, easily update, and uninstall.",
+analysis	Run Scorecard	2025-09-19T08:53:39.5096950Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Publish your project as a downloadable package, e.g., if hosted on GitHub, use [GitHub's mechanisms for publishing a package](https://docs.github.com/en/packages/learn-github-packages/publishing-a-package).\n\n- If hosted on GitHub, use a GitHub action to release your package to language-specific hubs.\n\n\n\n**Severity**: Medium\n\n\n\n**Details**:\n\nRisk: `Medium` (users possibly missing security updates)\n\n\n\nThis check tries to determine if the project is published as a package. It is\n\ncurrently limited to repositories hosted on GitHub, and does not support other\n\nsource hosting repositories (i.e., Forges).\n\n\n\nPackages give users of a project an easy way to download, install, update, and\n\nuninstall the software by a package manager. In particular, they make it easy\n\nfor users to receive security patches as updates.\n\n\n\nThe check currently looks for\n\n[GitHub packaging workflows](https://docs.github.com/en/packages/learn-github-packages/publishing-a-package)\n\nand language-specific GitHub Actions that upload the package to a corresponding\n\nhub, e.g., [Npm](https://www.npmjs.com/). We plan to add better support to query\n\npackage manager hubs directly in the future, e.g., for\n\n[Npm](https://www.npmjs.com/), [PyPi](https://pypi.org/).\n\n\n\nYou can create a package in several ways:\n\n\n\n  - Many program language ecosystems have a generally-used packaging format\n\n    supported by a language-level package manager tool and public package\n\n    repository.\n\n  - Many operating system platforms also have at least one package format,\n\n    tool, and public repository (in some cases the source repository generates\n\n    system-independent source packages, which are then used by others to\n\n    generate system executable packages).\n\n  - Using container images.\n\n\n\nNote: A project that fulfills this criterion with other tools may still receive\n\na low score on this test. There are many ways to package software, and it is\n\nchallenging for an automated tool like Scorecard to detect them all. A low\n\nscore is therefore not a definitive indication that the project is at risk. If\n\nScorecard fails to detect the way you publish a package and you think we should\n\nsupport your use case, please let us know by [opening an\n\nissue](https://github.com/ossf/scorecard/issues/new/choose).\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.5104439Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5104637Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5104879Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.5105086Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5105265Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5105483Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.5105729Z                         "problem.severity": "warning",
+analysis	Run Scorecard	2025-09-19T08:53:39.5105991Z                         "security-severity": "4.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.5106322Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5106534Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.5106755Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.5106963Z                            "releases"
+analysis	Run Scorecard	2025-09-19T08:53:39.5107168Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5107343Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5107501Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.5107667Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5107828Z                      "id": "SASTID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5108035Z                      "name": "SAST",
+analysis	Run Scorecard	2025-09-19T08:53:39.5108512Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#sast",
+analysis	Run Scorecard	2025-09-19T08:53:39.5109043Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5109266Z                         "text": "SAST"
+analysis	Run Scorecard	2025-09-19T08:53:39.5109476Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5109661Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5110016Z                         "text": "Determines if the project uses static code analysis."
+analysis	Run Scorecard	2025-09-19T08:53:39.5110311Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5110478Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5110750Z                         "text": "Determines if the project uses static code analysis.",
+analysis	Run Scorecard	2025-09-19T08:53:39.5115266Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Run CodeQL checks in your CI/CD by following the instructions [here](https://github.com/github/codeql-action#usage).\n\n\n\n**Severity**: Medium\n\n\n\n**Details**:\n\nRisk: `Medium` (possible unknown bugs)\n\n\n\nThis check tries to determine if the project uses Static Application Security\n\nTesting (SAST), also known as [static code analysis](https://owasp.org/www-community/controls/Static_Code_Analysis).\n\nIt is currently limited to repositories hosted on GitHub, and does not support\n\nother source hosting repositories (i.e., Forges).\n\n\n\nSAST is testing run on source code before the application is run. Using SAST\n\ntools can prevent known classes of bugs from being inadvertently introduced in the\n\ncodebase.\n\n\n\nThe checks currently looks for known Github apps such as\n\n[CodeQL](https://codeql.github.com/) (github-code-scanning) or\n\n[SonarCloud](https://sonarcloud.io/) in the recent (~30) merged PRs, or the use\n\nof \"github/codeql-action\" in a GitHub workflow. It also checks for the deprecated\n\n[LGTM](https://lgtm.com/) service until its forthcoming shutdown.\n\n\n\nNote: A project that fulfills this criterion with other tools may still receive\n\na low score on this test. There are many ways to implement SAST, and it is\n\nchallenging for an automated tool like Scorecard to detect them all. A low score\n\nis therefore not a definitive indication that the project is at risk.\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.5120191Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5120380Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5120622Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.5120831Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5121006Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5121225Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.5121467Z                         "problem.severity": "warning",
+analysis	Run Scorecard	2025-09-19T08:53:39.5121724Z                         "security-severity": "4.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.5121961Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5122173Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.5122392Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.5122600Z                            "testing"
+analysis	Run Scorecard	2025-09-19T08:53:39.5122795Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5122969Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5123127Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.5123289Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5123478Z                      "id": "SecurityPolicyID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5123721Z                      "name": "Security-Policy",
+analysis	Run Scorecard	2025-09-19T08:53:39.5124287Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#security-policy",
+analysis	Run Scorecard	2025-09-19T08:53:39.5124837Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5125083Z                         "text": "Security-Policy"
+analysis	Run Scorecard	2025-09-19T08:53:39.5125308Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5125505Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5125820Z                         "text": "Determines if the project has published a security policy."
+analysis	Run Scorecard	2025-09-19T08:53:39.5126135Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5126416Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5126700Z                         "text": "Determines if the project has published a security policy.",
+analysis	Run Scorecard	2025-09-19T08:53:39.5134237Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Place a security policy file `SECURITY.md` in the root directory of your repository. This makes it easily discoverable by a vulnerability reporter.\n\n- The file should contain information on what constitutes a vulnerability and a way to report it securely (e.g. issue tracker with private issue support, encrypted email with a published public key). Follow the [coordinated vulnerability disclosure guidelines](https://github.com/ossf/oss-vulnerability-guide/blob/main/maintainer-guide.md) to respond to vulnerability disclosures.\n\n- For GitHub, see more information [here](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).\n\n\n\n**Severity**: Medium\n\n\n\n**Details**:\n\nRisk: `Medium` (possible insecure reporting of vulnerabilities)\n\n\n\nThis check tries to determine if the project has published a security policy. It\n\nworks by looking for a file named `SECURITY.md` (case-insensitive) in a few\n\nwell-known directories.\n\n\n\nA security policy (typically a `SECURITY.md` file) can give users information\n\nabout what constitutes a vulnerability and how to report one securely so that\n\ninformation about a bug is not publicly visible.\n\n\n\nThis check examines the contents of the security policy file awarding points\n\nfor those policies that express vulnerability process(es), disclosure timelines,\n\nand have links (e.g., URL(s) and email(s)) to support the users.\n\n\n\nLinking Requirements (one or more) (6/10 points):\n\n  - A valid form of an email address to contact for vulnerabilities\n\n  - A valid form of a http/https address to support vulnerability reporting\n\n\n\nFree Form Text (3/10 points):\n\n  - Free form text is present in the security policy file which is beyond\n\n    simply having a http/https address and/or email in the file\n\n  - The string length of any such links in the policy file do not count\n\n    towards detecting free form text\n\n\n\nSecurity Policy Specific Text (1/10 points):\n\n  - Specific text providing basic or general information about vulnerability\n\n    and disclosure practices, expectations, and/or timelines\n\n  - Text should include a total of 2 or more hits which match (case insensitive)\n\n    `vuln` and as in \"Vulnerability\" or \"vulnerabilities\";\n\n    `disclos` as \"Disclosure\" or \"disclose\";\n\n    and numbers which convey expectations of times, e.g., 30 days or 90 days\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.5142071Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5142267Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5142508Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.5142727Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5142903Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5143127Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.5143371Z                         "problem.severity": "warning",
+analysis	Run Scorecard	2025-09-19T08:53:39.5143634Z                         "security-severity": "4.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.5143865Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5144089Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.5144319Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.5144530Z                            "policy"
+analysis	Run Scorecard	2025-09-19T08:53:39.5144736Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5144910Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5145081Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.5145240Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5145425Z                      "id": "SignedReleasesID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5145670Z                      "name": "Signed-Releases",
+analysis	Run Scorecard	2025-09-19T08:53:39.5146334Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#signed-releases",
+analysis	Run Scorecard	2025-09-19T08:53:39.5146898Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5147141Z                         "text": "Signed-Releases"
+analysis	Run Scorecard	2025-09-19T08:53:39.5147376Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5147563Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5147920Z                         "text": "Determines if the project cryptographically signs release artifacts."
+analysis	Run Scorecard	2025-09-19T08:53:39.5148259Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5148438Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5148750Z                         "text": "Determines if the project cryptographically signs release artifacts.",
+analysis	Run Scorecard	2025-09-19T08:53:39.5153697Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Publish the release.\n\n- Generate a signing key.\n\n- Download the release as an archive locally.\n\n- Sign the release archive with this key (should output a signature file).\n\n- Attach the signature file next to the release archive.\n\n- If the source is hosted on GitHub, check out the steps [here](https://wiki.debian.org/Creating%20signed%20GitHub%20releases).\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nRisk: `High` (possibility of installing malicious releases)\n\n\n\nThis check tries to determine if the project cryptographically signs release\n\nartifacts. It is currently limited to repositories hosted on GitHub, and does\n\nnot support other source hosting repositories (i.e., Forges).\n\n\n\nSigned releases attest to the provenance of the artifact.\n\n\n\nThis check looks for the following filenames in the project's last five\n\n[release assets](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases):\n\n[*.minisig](https://github.com/jedisct1/minisign), *.asc (pgp),\n\n*.sig, *.sign, [*.intoto.jsonl](https://slsa.dev).\n\n\n\nIf a signature is found in the assets for each release, a score of 8 is given.\n\nIf a [SLSA provenance file](https://slsa.dev/spec/v0.1/index) is found in the assets for each release (*.intoto.jsonl), the maximum score of 10 is given.\n\n\n\nThis check looks for the 30 most recent releases associated with an artifact. It ignores the source code-only releases that are created automatically by GitHub.\n\n\n\nNote: The check does not verify the signatures.\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.5158951Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5159153Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5159400Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.5159611Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5159795Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5160015Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.5160265Z                         "problem.severity": "error",
+analysis	Run Scorecard	2025-09-19T08:53:39.5160524Z                         "security-severity": "7.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.5160773Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5160981Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.5161209Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.5161426Z                            "releases"
+analysis	Run Scorecard	2025-09-19T08:53:39.5161625Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5161804Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5161965Z                   },
+analysis	Run Scorecard	2025-09-19T08:53:39.5162128Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5162311Z                      "id": "VulnerabilitiesID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5162560Z                      "name": "Vulnerabilities",
+analysis	Run Scorecard	2025-09-19T08:53:39.5163116Z                      "helpUri": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#vulnerabilities",
+analysis	Run Scorecard	2025-09-19T08:53:39.5163678Z                      "shortDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5163922Z                         "text": "Vulnerabilities"
+analysis	Run Scorecard	2025-09-19T08:53:39.5164148Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5164339Z                      "fullDescription": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5164677Z                         "text": "Determines if the project has open, known unfixed vulnerabilities."
+analysis	Run Scorecard	2025-09-19T08:53:39.5165015Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5165185Z                      "help": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5165495Z                         "text": "Determines if the project has open, known unfixed vulnerabilities.",
+analysis	Run Scorecard	2025-09-19T08:53:39.5169076Z                         "markdown": "**Remediation (click \"Show more\" below)**:\n\n- Fix the vulnerabilities in your own code base. The details of each vulnerability can be found on \u003chttps://osv.dev\u003e.\n\n- If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.\n\n- If you believe the vulnerability does not affect your project, the  vulnerability can be ignored.  To ignore, create an `osv-scanner.toml` file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of `osv-scanner.toml` can be found on  [OSV-Scanner repository](https://github.com/google/osv-scanner#ignore-vulnerabilities-by-id).\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nRisk: `High`  (known vulnerabilities)\n\n\n\nThis check determines whether the project has open, unfixed vulnerabilities \n\nin its own codebase or its dependencies using the [OSV (Open Source Vulnerabilities)](https://osv.dev/) service.\n\nAn open vulnerability is readily exploited by attackers and should be fixed as soon as\n\npossible.\n\n"
+analysis	Run Scorecard	2025-09-19T08:53:39.5172883Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5173074Z                      "defaultConfiguration": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5173320Z                         "level": "error"
+analysis	Run Scorecard	2025-09-19T08:53:39.5173531Z                      },
+analysis	Run Scorecard	2025-09-19T08:53:39.5173708Z                      "properties": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5173927Z                         "precision": "high",
+analysis	Run Scorecard	2025-09-19T08:53:39.5174282Z                         "problem.severity": "error",
+analysis	Run Scorecard	2025-09-19T08:53:39.5174536Z                         "security-severity": "7.0",
+analysis	Run Scorecard	2025-09-19T08:53:39.5174776Z                         "tags": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5174991Z                            "supply-chain",
+analysis	Run Scorecard	2025-09-19T08:53:39.5175211Z                            "security",
+analysis	Run Scorecard	2025-09-19T08:53:39.5175436Z                            "vulnerabilities"
+analysis	Run Scorecard	2025-09-19T08:53:39.5175651Z                         ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5175839Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5176001Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.5176160Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5176417Z             }
+analysis	Run Scorecard	2025-09-19T08:53:39.5176570Z          },
+analysis	Run Scorecard	2025-09-19T08:53:39.5176716Z          "results": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5176886Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.5177060Z                "ruleId": "CIIBestPracticesID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5177302Z                "ruleIndex": 1,
+analysis	Run Scorecard	2025-09-19T08:53:39.5177501Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5177966Z                   "text": "score is 0: no effort to earn an OpenSSF best practices badge detected\nClick Remediation section below to solve this issue"
+analysis	Run Scorecard	2025-09-19T08:53:39.5178455Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.5178619Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5178810Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5178983Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5179215Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5179429Z                            "startLine": 1
+analysis	Run Scorecard	2025-09-19T08:53:39.5179644Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.5179840Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5180097Z                            "uri": "no file associated with this alert",
+analysis	Run Scorecard	2025-09-19T08:53:39.5180373Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.5180599Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.5180771Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5180930Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.5181092Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5181252Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.5181311Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.5181396Z                "ruleId": "CodeReviewID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5181467Z                "ruleIndex": 2,
+analysis	Run Scorecard	2025-09-19T08:53:39.5181537Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5181899Z                   "text": "score is 6: found 11 unreviewed changesets out of 30 -- score normalized to 6\nClick Remediation section below to solve this issue"
+analysis	Run Scorecard	2025-09-19T08:53:39.5181965Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.5182033Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5182099Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5182179Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5182248Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5182323Z                            "startLine": 1
+analysis	Run Scorecard	2025-09-19T08:53:39.5182393Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.5182473Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5182574Z                            "uri": "no file associated with this alert",
+analysis	Run Scorecard	2025-09-19T08:53:39.5182664Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.5182727Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.5182788Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5182848Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.5182913Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5182972Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.5183030Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.5183112Z                "ruleId": "FuzzingID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5183306Z                "ruleIndex": 4,
+analysis	Run Scorecard	2025-09-19T08:53:39.5183372Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5193269Z                   "text": "score is 0: project is not fuzzed:\nWarn: no OSSFuzz integration found: Follow the steps in https://github.com/google/oss-fuzz to integrate fuzzing for your project.\nOver time, try to add fuzzing for more functionalities of your project. (High effort)\nWarn: no OneFuzz integration found: Follow the steps in https://github.com/microsoft/onefuzz to start fuzzing for your project.\nOver time, try to add fuzzing for more functionalities of your project. (High effort)\nWarn: no GoBuiltInFuzzer integration found: Follow the steps in https://go.dev/doc/fuzz/ to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no PythonAtherisFuzzer integration found: Follow the steps in https://github.com/google/atheris to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no CLibFuzzer integration found: Follow the steps in https://llvm.org/docs/LibFuzzer.html to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no CppLibFuzzer integration found: Follow the steps in https://llvm.org/docs/LibFuzzer.html to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no SwiftLibFuzzer integration found: Follow the steps in https://google.github.io/oss-fuzz/getting-started/new-project-guide/swift-lang/ to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no RustCargoFuzzer integration found: Follow the steps in https://rust-fuzz.github.io/book/cargo-fuzz.html to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no JavaJazzerFuzzer integration found: Follow the steps in https://github.com/CodeIntelligenceTesting/jazzer to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no ClusterFuzzLite integration found: Follow the steps in https://github.com/google/clusterfuzzlite to integrate fuzzing as part of CI.\nOver time, try to add fuzzing for more functionalities of your project. (High effort)\nWarn: no HaskellPropertyBasedTesting integration found: Use one of the following frameworks to fuzz your project:\nQuickCheck: https://hackage.haskell.org/package/QuickCheck\nhedgehog: https://hedgehog.qa/\nvalidity: https://github.com/NorfairKing/validity\nsmallcheck: https://hackage.haskell.org/package/smallcheck\nhspec: https://hspec.github.io/\ntasty: https://hackage.haskell.org/package/tasty (High effort)\nWarn: no TypeScriptPropertyBasedTesting integration found: Use fast-check: https://github.com/dubzzz/fast-check (High effort)\nWarn: no JavaScriptPropertyBasedTesting integration found: Use fast-check: https://github.com/dubzzz/fast-check (High effort)\nClick Remediation section below to solve this issue"
+analysis	Run Scorecard	2025-09-19T08:53:39.5193470Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.5193539Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5193604Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5193683Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5193750Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5193826Z                            "startLine": 1
+analysis	Run Scorecard	2025-09-19T08:53:39.5193891Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.5193972Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5194073Z                            "uri": "no file associated with this alert",
+analysis	Run Scorecard	2025-09-19T08:53:39.5194156Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.5194218Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.5194277Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5194341Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.5194399Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5194562Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.5194620Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.5194704Z                "ruleId": "MaintainedID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5194772Z                "ruleIndex": 5,
+analysis	Run Scorecard	2025-09-19T08:53:39.5194836Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5195502Z                   "text": "score is 0: repo was created 4 days ago, not enough maintenance history:\nWarn: repo was created in the last 90 days (Created at: 2025-09-14T20:43:38Z), please review its contents carefully\nClick Remediation section below to solve this issue"
+analysis	Run Scorecard	2025-09-19T08:53:39.5195638Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.5195704Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5195770Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5195848Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5195915Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5195986Z                            "startLine": 1
+analysis	Run Scorecard	2025-09-19T08:53:39.5196054Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.5196139Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5196331Z                            "uri": "no file associated with this alert",
+analysis	Run Scorecard	2025-09-19T08:53:39.5196418Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.5196480Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.5196540Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5196604Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.5196663Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5196722Z             }
+analysis	Run Scorecard	2025-09-19T08:53:39.5196779Z          ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5196848Z       }
+analysis	Run Scorecard	2025-09-19T08:53:39.5196908Z    ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5196969Z }
+analysis	Run Scorecard	2025-09-19T08:53:39.5197784Z EnvGithubAuthToken: GITHUB_AUTH_TOKEN ***
+analysis	Run Scorecard	2025-09-19T08:53:39.5197866Z Scorecard options:
+analysis	Run Scorecard	2025-09-19T08:53:39.5197928Z Ref: HEAD
+analysis	Run Scorecard	2025-09-19T08:53:39.5198033Z Repository: CoderDeltaLAN/ci-matrix-starter
+analysis	Run Scorecard	2025-09-19T08:53:39.5198101Z Local:
+analysis	Run Scorecard	2025-09-19T08:53:39.5198169Z Format: json
+analysis	Run Scorecard	2025-09-19T08:53:39.5198235Z Policy file:
+analysis	Run Scorecard	2025-09-19T08:53:39.5198239Z
+analysis	Run Scorecard	2025-09-19T08:53:39.5198327Z Event / repo information:
+analysis	Run Scorecard	2025-09-19T08:53:39.5198418Z Event file: /github/workflow/event.json
+analysis	Run Scorecard	2025-09-19T08:53:39.5198498Z Event name: workflow_dispatch
+analysis	Run Scorecard	2025-09-19T08:53:39.5198570Z Fork repository: false
+analysis	Run Scorecard	2025-09-19T08:53:39.5198652Z Private repository: false
+analysis	Run Scorecard	2025-09-19T08:53:39.5198729Z Publication enabled: false
+analysis	Run Scorecard	2025-09-19T08:53:39.5198797Z Default branch: main
+analysis	Run Scorecard	2025-09-19T08:53:50.3953918Z Using payload from: results.json
+analysis	Run Scorecard	2025-09-19T08:53:50.3954374Z Generating ephemeral keys...
+analysis	Run Scorecard	2025-09-19T08:53:50.4014871Z {"date":"2025-09-19T08:53:39Z","repo":{"name":"github.com/CoderDeltaLAN/ci-matrix-starter","commit":"43e5312972e616133477e24b9edc9e4eee085ba1"},"scorecard":{"version":"v4.13.1","commit":"49c0eed3a423f00c872b5c3c9f1bbca9e8aae799"},"score":5.6,"checks":[{"details":null,"score":10,"reason":"no binaries found in the repo","name":"Binary-Artifacts","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#binary-artifacts","short":"Determines if the project has generated executable (binary) artifacts in the source repository."}},{"details":null,"score":-1,"reason":"internal error: error during branchesHandler.setup: internal error: githubv4.Query: Resource not accessible by integration","name":"Branch-Protection","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#branch-protection","short":"Determines if the default and release branches are protected with GitHub's branch protection settings."}},{"details":null,"score":10,"reason":"28 out of 28 merged PRs checked by a CI test -- score normalized to 10","name":"CI-Tests","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#ci-tests","short":"Determines if the project runs tests before pull requests are merged."}},{"details":null,"score":0,"reason":"no effort to earn an OpenSSF best practices badge detected","name":"CII-Best-Practices","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#cii-best-practices","short":"Determines if the project has an OpenSSF (formerly CII) Best Practices Badge."}},{"details":null,"score":6,"reason":"found 11 unreviewed changesets out of 30 -- score normalized to 6","name":"Code-Review","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#code-review","short":"Determines if the project requires human code review before pull requests (aka merge requests) are merged."}},{"details":["Info: contributors work for coderdeltalan (independent oss maintainer)"],"score":3,"reason":"1 different organizations found -- score normalized to 3","name":"Contributors","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#contributors","short":"Determines if the project has a set of contributors from multiple organizations (e.g., companies)."}},{"details":null,"score":10,"reason":"no dangerous workflow patterns detected","name":"Dangerous-Workflow","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#dangerous-workflow","short":"Determines if the project's GitHub Action workflows avoid dangerous patterns."}},{"details":["Warn: tool 'RenovateBot' is not used: Follow the instructions from https://docs.renovatebot.com/configuration-options/. (Low effort)","Warn: tool 'Dependabot' is not used: Follow the instructions from https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates. (Low effort)","Warn: tool 'PyUp' is not used: Follow the instructions from https://docs.pyup.io/docs. (Low effort)","Warn: tool 'Sonatype Lift' is not used: Follow the instructions from https://help.sonatype.com/lift/getting-started. (Low effort)"],"score":0,"reason":"no update tool detected","name":"Dependency-Update-Tool","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#dependency-update-tool","short":"Determines if the project uses a dependency update tool."}},{"details":["Warn: no OSSFuzz integration found: Follow the steps in https://github.com/google/oss-fuzz to integrate fuzzing for your project.\nOver time, try to add fuzzing for more functionalities of your project. (High effort)","Warn: no OneFuzz integration found: Follow the steps in https://github.com/microsoft/onefuzz to start fuzzing for your project.\nOver time, try to add fuzzing for more functionalities of your project. (High effort)","Warn: no GoBuiltInFuzzer integration found: Follow the steps in https://go.dev/doc/fuzz/ to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no PythonAtherisFuzzer integration found: Follow the steps in https://github.com/google/atheris to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no CLibFuzzer integration found: Follow the steps in https://llvm.org/docs/LibFuzzer.html to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no CppLibFuzzer integration found: Follow the steps in https://llvm.org/docs/LibFuzzer.html to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no SwiftLibFuzzer integration found: Follow the steps in https://google.github.io/oss-fuzz/getting-started/new-project-guide/swift-lang/ to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no RustCargoFuzzer integration found: Follow the steps in https://rust-fuzz.github.io/book/cargo-fuzz.html to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no JavaJazzerFuzzer integration found: Follow the steps in https://github.com/CodeIntelligenceTesting/jazzer to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no ClusterFuzzLite integration found: Follow the steps in https://github.com/google/clusterfuzzlite to integrate fuzzing as part of CI.\nOver time, try to add fuzzing for more functionalities of your project. (High effort)","Warn: no HaskellPropertyBasedTesting integration found: Use one of the following frameworks to fuzz your project:\nQuickCheck: https://hackage.haskell.org/package/QuickCheck\nhedgehog: https://hedgehog.qa/\nvalidity: https://github.com/NorfairKing/validity\nsmallcheck: https://hackage.haskell.org/package/smallcheck\nhspec: https://hspec.github.io/\ntasty: https://hackage.haskell.org/package/tasty (High effort)","Warn: no TypeScriptPropertyBasedTesting integration found: Use fast-check: https://github.com/dubzzz/fast-check (High effort)","Warn: no JavaScriptPropertyBasedTesting integration found: Use fast-check: https://github.com/dubzzz/fast-check (High effort)"],"score":0,"reason":"project is not fuzzed","name":"Fuzzing","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#fuzzing","short":"Determines if the project uses fuzzing."}},{"details":null,"score":0,"reason":"license file not detected","name":"License","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#license","short":"Determines if the project has defined a license."}},{"details":["Warn: repo was created in the last 90 days (Created at: 2025-09-14T20:43:38Z), please review its contents carefully"],"score":0,"reason":"repo was created 4 days ago, not enough maintenance history","name":"Maintained","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#maintained","short":"Determines if the project is \"actively maintained\"."}},{"details":["Info: GitHub/GitLab publishing workflow used in run https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/actions/runs/17849131652: .github/workflows/ghcr-publish.yml:10"],"score":10,"reason":"publishing workflow detected","name":"Packaging","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#packaging","short":"Determines if the project is published as a package that others can easily download, install, easily update, and uninstall."}},{"details":null,"score":-1,"reason":"internal error: internal error: unable to determine OS for job: node${{ matrix.node }} • ${{ matrix.os }}","name":"Pinned-Dependencies","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#pinned-dependencies","short":"Determines if the project has declared and pinned the dependencies of its build process."}},{"details":["Info: all commits (28) are checked with a SAST tool","Info: SAST tool detected: CodeQL"],"score":10,"reason":"SAST tool is run on all commits","name":"SAST","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#sast","short":"Determines if the project uses static code analysis."}},{"details":["Info: security policy file detected: SECURITY.md:1","Info: Found linked content: SECURITY.md:1","Info: Found disclosure, vulnerability, and/or timelines in security policy: SECURITY.md:1","Info: Found text in security policy: SECURITY.md:1"],"score":10,"reason":"security policy file detected","name":"Security-Policy","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#security-policy","short":"Determines if the project has published a security policy."}},{"details":["Warn: no GitHub releases found"],"score":-1,"reason":"no releases found","name":"Signed-Releases","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#signed-releases","short":"Determines if the project cryptographically signs release artifacts."}},{"details":["Info: topLevel 'contents' permission set to 'read': .github/workflows/build.yml:9","Warn: topLevel 'security-events' permission set to 'write': .github/workflows/build.yml:10: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/build.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Info: topLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:12","Warn: topLevel 'security-events' permission set to 'write': .github/workflows/codeql.yml:13: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/codeql.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Warn: topLevel 'contents' permission set to 'write': .github/workflows/dependabot-auto-merge.yml:11: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/dependabot-auto-merge.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Info: topLevel 'contents' permission set to 'read': .github/workflows/ghcr-publish.yml:7","Warn: topLevel 'packages' permission set to 'write': .github/workflows/ghcr-publish.yml:8: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/ghcr-publish.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Info: topLevel 'contents' permission set to 'read': .github/workflows/labeler.yml:6","Info: topLevel 'contents' permission set to 'read': .github/workflows/npm-gpr.yml:7","Warn: topLevel 'packages' permission set to 'write': .github/workflows/npm-gpr.yml:8: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/npm-gpr.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Info: topLevel 'contents' permission set to 'read': .github/workflows/publish-pypi.yml:8","Info: topLevel 'contents' permission set to 'read': .github/workflows/py-ci.yml:20","Warn: topLevel 'contents' permission set to 'write': .github/workflows/release-drafter.yml:10: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/release-drafter.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Warn: topLevel 'contents' permission set to 'write': .github/workflows/release-sbom.yml:7: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/release-sbom.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Info: topLevel 'contents' permission set to 'read': .github/workflows/scorecards.yml:10","Info: jobLevel 'contents' permission set to 'read': .github/workflows/scorecards.yml:22","Warn: topLevel 'statuses' permission set to 'write': .github/workflows/semantic-pr.yml:7: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/semantic-pr.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Warn: no topLevel permission defined: .github/workflows/supply-chain.yml:1: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/supply-chain.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Warn: jobLevel 'contents' permission set to 'write': .github/workflows/supply-chain.yml:12: Verify which permissions are needed and consider whether you can reduce them. (High effort)","Info: topLevel 'contents' permission set to 'read': .github/workflows/ts-ci.yml:24"],"score":0,"reason":"detected GitHub workflow tokens with excessive permissions","name":"Token-Permissions","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#token-permissions","short":"Determines if the project's workflows follow the principle of least privilege."}},{"details":null,"score":10,"reason":"no vulnerabilities detected","name":"Vulnerabilities","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#vulnerabilities","short":"Determines if the project has open, known unfixed vulnerabilities."}}],"metadata":null}
+analysis	Run Scorecard	2025-09-19T08:53:50.4788379Z Retrieving signed certificate...
+analysis	Run Scorecard	2025-09-19T08:53:50.9265801Z Successfully verified SCT...
+analysis	Run Scorecard	2025-09-19T08:53:50.9266537Z
+analysis	Run Scorecard	2025-09-19T08:53:50.9268640Z 	The sigstore service, hosted by sigstore a Series of LF Projects, LLC, is provided pursuant to the Hosted Project Tools Terms of Use, available at https://lfprojects.org/policies/hosted-project-tools-terms-of-use/.
+analysis	Run Scorecard	2025-09-19T08:53:50.9270915Z 	Note that if your submission includes personal data associated with this signed artifact, it will be part of an immutable record.
+analysis	Run Scorecard	2025-09-19T08:53:50.9272564Z 	This may include the email address associated with the account with which you authenticate your contractual Agreement.
+analysis	Run Scorecard	2025-09-19T08:53:50.9274904Z 	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later, and is subject to the Immutable Record notice at https://lfprojects.org/policies/hosted-project-tools-immutable-records/.
+analysis	Run Scorecard	2025-09-19T08:53:50.9276869Z
+analysis	Run Scorecard	2025-09-19T08:53:50.9277947Z By typing 'y', you attest that (1) you are not submitting the personal data of any other person; and (2) you understand and agree to the statement and the Agreement terms at the URLs listed above.
+analysis	Run Scorecard	2025-09-19T08:53:50.9279359Z using ephemeral certificate:
+analysis	Run Scorecard	2025-09-19T08:53:50.9279821Z -----BEGIN CERTIFICATE-----
+analysis	Run Scorecard	2025-09-19T08:53:50.9280562Z MIIHKzCCBrKgAwIBAgIUBwLgLAGsCmZ0QQo+0Gy5SuZeipEwCgYIKoZIzj0EAwMw
+analysis	Run Scorecard	2025-09-19T08:53:50.9281479Z NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
+analysis	Run Scorecard	2025-09-19T08:53:50.9282336Z cm1lZGlhdGUwHhcNMjUwOTE5MDg1MzUwWhcNMjUwOTE5MDkwMzUwWjAAMFkwEwYH
+analysis	Run Scorecard	2025-09-19T08:53:50.9282828Z KoZIzj0CAQYIKoZIzj0DAQcDQgAE+j/m2ZaVh33J/VeQrBO8Ik6vb1H7HJPTLGJU
+analysis	Run Scorecard	2025-09-19T08:53:50.9283274Z X0xJ2PmV1+f5HUMKT/CeyMiJhBhO74cReH76IcgY7QBNN52MF6OCBdEwggXNMA4G
+analysis	Run Scorecard	2025-09-19T08:53:50.9283736Z A1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUjcEf
+analysis	Run Scorecard	2025-09-19T08:53:50.9284208Z pP36zbVudjmPRSbGKYw0u4IwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y
+analysis	Run Scorecard	2025-09-19T08:53:50.9284684Z ZD8wcQYDVR0RAQH/BGcwZYZjaHR0cHM6Ly9naXRodWIuY29tL0NvZGVyRGVsdGFM
+analysis	Run Scorecard	2025-09-19T08:53:50.9285143Z QU4vY2ktbWF0cml4LXN0YXJ0ZXIvLmdpdGh1Yi93b3JrZmxvd3Mvc2NvcmVjYXJk
+analysis	Run Scorecard	2025-09-19T08:53:50.9285613Z cy55bWxAcmVmcy9oZWFkcy9tYWluMDkGCisGAQQBg78wAQEEK2h0dHBzOi8vdG9r
+analysis	Run Scorecard	2025-09-19T08:53:50.9286078Z ZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVudC5jb20wHwYKKwYBBAGDvzABAgQR
+analysis	Run Scorecard	2025-09-19T08:53:50.9286688Z d29ya2Zsb3dfZGlzcGF0Y2gwNgYKKwYBBAGDvzABAwQoNDNlNTMxMjk3MmU2MTYx
+analysis	Run Scorecard	2025-09-19T08:53:50.9287145Z MzM0NzdlMjRiOWVkYzllNGVlZTA4NWJhMTAfBgorBgEEAYO/MAEEBBFPcGVuU1NG
+analysis	Run Scorecard	2025-09-19T08:53:50.9287825Z IFNjb3JlY2FyZDAtBgorBgEEAYO/MAEFBB9Db2RlckRlbHRhTEFOL2NpLW1hdHJp
+analysis	Run Scorecard	2025-09-19T08:53:50.9288281Z eC1zdGFydGVyMB0GCisGAQQBg78wAQYED3JlZnMvaGVhZHMvbWFpbjA7BgorBgEE
+analysis	Run Scorecard	2025-09-19T08:53:50.9288740Z AYO/MAEIBC0MK2h0dHBzOi8vdG9rZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVu
+analysis	Run Scorecard	2025-09-19T08:53:50.9289216Z dC5jb20wcwYKKwYBBAGDvzABCQRlDGNodHRwczovL2dpdGh1Yi5jb20vQ29kZXJE
+analysis	Run Scorecard	2025-09-19T08:53:50.9289683Z ZWx0YUxBTi9jaS1tYXRyaXgtc3RhcnRlci8uZ2l0aHViL3dvcmtmbG93cy9zY29y
+analysis	Run Scorecard	2025-09-19T08:53:50.9290152Z ZWNhcmRzLnltbEByZWZzL2hlYWRzL21haW4wOAYKKwYBBAGDvzABCgQqDCg0M2U1
+analysis	Run Scorecard	2025-09-19T08:53:50.9290762Z MzEyOTcyZTYxNjEzMzQ3N2UyNGI5ZWRjOWU0ZWVlMDg1YmExMB0GCisGAQQBg78w
+analysis	Run Scorecard	2025-09-19T08:53:50.9291223Z AQsEDwwNZ2l0aHViLWhvc3RlZDBCBgorBgEEAYO/MAEMBDQMMmh0dHBzOi8vZ2l0
+analysis	Run Scorecard	2025-09-19T08:53:50.9291682Z aHViLmNvbS9Db2RlckRlbHRhTEFOL2NpLW1hdHJpeC1zdGFydGVyMDgGCisGAQQB
+analysis	Run Scorecard	2025-09-19T08:53:50.9292148Z g78wAQ0EKgwoNDNlNTMxMjk3MmU2MTYxMzM0NzdlMjRiOWVkYzllNGVlZTA4NWJh
+analysis	Run Scorecard	2025-09-19T08:53:50.9292606Z MTAfBgorBgEEAYO/MAEOBBEMD3JlZnMvaGVhZHMvbWFpbjAaBgorBgEEAYO/MAEP
+analysis	Run Scorecard	2025-09-19T08:53:50.9293074Z BAwMCjEwNTY4MDM0MzAwMAYKKwYBBAGDvzABEAQiDCBodHRwczovL2dpdGh1Yi5j
+analysis	Run Scorecard	2025-09-19T08:53:50.9293522Z b20vQ29kZXJEZWx0YUxBTjAZBgorBgEEAYO/MAERBAsMCTE1MjA0Mzc0NTBzBgor
+analysis	Run Scorecard	2025-09-19T08:53:50.9293968Z BgEEAYO/MAESBGUMY2h0dHBzOi8vZ2l0aHViLmNvbS9Db2RlckRlbHRhTEFOL2Np
+analysis	Run Scorecard	2025-09-19T08:53:50.9294421Z LW1hdHJpeC1zdGFydGVyLy5naXRodWIvd29ya2Zsb3dzL3Njb3JlY2FyZHMueW1s
+analysis	Run Scorecard	2025-09-19T08:53:50.9294873Z QHJlZnMvaGVhZHMvbWFpbjA4BgorBgEEAYO/MAETBCoMKDQzZTUzMTI5NzJlNjE2
+analysis	Run Scorecard	2025-09-19T08:53:50.9295324Z MTMzNDc3ZTI0YjllZGM5ZTRlZWUwODViYTEwIQYKKwYBBAGDvzABFAQTDBF3b3Jr
+analysis	Run Scorecard	2025-09-19T08:53:50.9295786Z Zmxvd19kaXNwYXRjaDBmBgorBgEEAYO/MAEVBFgMVmh0dHBzOi8vZ2l0aHViLmNv
+analysis	Run Scorecard	2025-09-19T08:53:50.9296347Z bS9Db2RlckRlbHRhTEFOL2NpLW1hdHJpeC1zdGFydGVyL2FjdGlvbnMvcnVucy8x
+analysis	Run Scorecard	2025-09-19T08:53:50.9296815Z Nzg1MzUyODA4MC9hdHRlbXB0cy8xMBYGCisGAQQBg78wARYECAwGcHVibGljMIGK
+analysis	Run Scorecard	2025-09-19T08:53:50.9297282Z BgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4py
+analysis	Run Scorecard	2025-09-19T08:53:50.9297739Z gC8p7o4AAAGZYS4HYgAABAMARzBFAiAEna3Ii39So59V3MWriXewCLGSWF1d04VI
+analysis	Run Scorecard	2025-09-19T08:53:50.9298204Z k3nTZreeNwIhAPEjNaZ+5o1txiV9GErSZaV905uNqXosyyIiYH+oqmo7MAoGCCqG
+analysis	Run Scorecard	2025-09-19T08:53:50.9298648Z SM49BAMDA2cAMGQCMErTBDCdLPnbo/2LDspjQbirOBJ0npxymCPeJI90ftJi8yzp
+analysis	Run Scorecard	2025-09-19T08:53:50.9299084Z /N1/ug58guDe+zUKTgIwf9can2d6+w+3x37rkDsZ4EmkN+V0xGPPB+gCkWk+4ZBX
+analysis	Run Scorecard	2025-09-19T08:53:50.9299420Z lc6JPxyB7nsy8HyQeeET
+analysis	Run Scorecard	2025-09-19T08:53:50.9299610Z -----END CERTIFICATE-----
+analysis	Run Scorecard	2025-09-19T08:53:50.9299744Z
+analysis	Run Scorecard	2025-09-19T08:53:51.2787863Z tlog entry created with index: 537222745
+analysis	Run Scorecard	2025-09-19T08:53:51.2788744Z using ephemeral certificate:
+analysis	Run Scorecard	2025-09-19T08:53:51.2789207Z -----BEGIN CERTIFICATE-----
+analysis	Run Scorecard	2025-09-19T08:53:51.2789915Z MIIHKzCCBrKgAwIBAgIUBwLgLAGsCmZ0QQo+0Gy5SuZeipEwCgYIKoZIzj0EAwMw
+analysis	Run Scorecard	2025-09-19T08:53:51.2790903Z NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
+analysis	Run Scorecard	2025-09-19T08:53:51.2791771Z cm1lZGlhdGUwHhcNMjUwOTE5MDg1MzUwWhcNMjUwOTE5MDkwMzUwWjAAMFkwEwYH
+analysis	Run Scorecard	2025-09-19T08:53:51.2792563Z KoZIzj0CAQYIKoZIzj0DAQcDQgAE+j/m2ZaVh33J/VeQrBO8Ik6vb1H7HJPTLGJU
+analysis	Run Scorecard	2025-09-19T08:53:51.2793131Z X0xJ2PmV1+f5HUMKT/CeyMiJhBhO74cReH76IcgY7QBNN52MF6OCBdEwggXNMA4G
+analysis	Run Scorecard	2025-09-19T08:53:51.2793722Z A1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUjcEf
+analysis	Run Scorecard	2025-09-19T08:53:51.2794323Z pP36zbVudjmPRSbGKYw0u4IwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y
+analysis	Run Scorecard	2025-09-19T08:53:51.2794897Z ZD8wcQYDVR0RAQH/BGcwZYZjaHR0cHM6Ly9naXRodWIuY29tL0NvZGVyRGVsdGFM
+analysis	Run Scorecard	2025-09-19T08:53:51.2795450Z QU4vY2ktbWF0cml4LXN0YXJ0ZXIvLmdpdGh1Yi93b3JrZmxvd3Mvc2NvcmVjYXJk
+analysis	Run Scorecard	2025-09-19T08:53:51.2796028Z cy55bWxAcmVmcy9oZWFkcy9tYWluMDkGCisGAQQBg78wAQEEK2h0dHBzOi8vdG9r
+analysis	Run Scorecard	2025-09-19T08:53:51.2796870Z ZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVudC5jb20wHwYKKwYBBAGDvzABAgQR
+analysis	Run Scorecard	2025-09-19T08:53:51.2797392Z d29ya2Zsb3dfZGlzcGF0Y2gwNgYKKwYBBAGDvzABAwQoNDNlNTMxMjk3MmU2MTYx
+analysis	Run Scorecard	2025-09-19T08:53:51.2797841Z MzM0NzdlMjRiOWVkYzllNGVlZTA4NWJhMTAfBgorBgEEAYO/MAEEBBFPcGVuU1NG
+analysis	Run Scorecard	2025-09-19T08:53:51.2798277Z IFNjb3JlY2FyZDAtBgorBgEEAYO/MAEFBB9Db2RlckRlbHRhTEFOL2NpLW1hdHJp
+analysis	Run Scorecard	2025-09-19T08:53:51.2798719Z eC1zdGFydGVyMB0GCisGAQQBg78wAQYED3JlZnMvaGVhZHMvbWFpbjA7BgorBgEE
+analysis	Run Scorecard	2025-09-19T08:53:51.2799166Z AYO/MAEIBC0MK2h0dHBzOi8vdG9rZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVu
+analysis	Run Scorecard	2025-09-19T08:53:51.2799866Z dC5jb20wcwYKKwYBBAGDvzABCQRlDGNodHRwczovL2dpdGh1Yi5jb20vQ29kZXJE
+analysis	Run Scorecard	2025-09-19T08:53:51.2800326Z ZWx0YUxBTi9jaS1tYXRyaXgtc3RhcnRlci8uZ2l0aHViL3dvcmtmbG93cy9zY29y
+analysis	Run Scorecard	2025-09-19T08:53:51.2800788Z ZWNhcmRzLnltbEByZWZzL2hlYWRzL21haW4wOAYKKwYBBAGDvzABCgQqDCg0M2U1
+analysis	Run Scorecard	2025-09-19T08:53:51.2801256Z MzEyOTcyZTYxNjEzMzQ3N2UyNGI5ZWRjOWU0ZWVlMDg1YmExMB0GCisGAQQBg78w
+analysis	Run Scorecard	2025-09-19T08:53:51.2801716Z AQsEDwwNZ2l0aHViLWhvc3RlZDBCBgorBgEEAYO/MAEMBDQMMmh0dHBzOi8vZ2l0
+analysis	Run Scorecard	2025-09-19T08:53:51.2802291Z aHViLmNvbS9Db2RlckRlbHRhTEFOL2NpLW1hdHJpeC1zdGFydGVyMDgGCisGAQQB
+analysis	Run Scorecard	2025-09-19T08:53:51.2802749Z g78wAQ0EKgwoNDNlNTMxMjk3MmU2MTYxMzM0NzdlMjRiOWVkYzllNGVlZTA4NWJh
+analysis	Run Scorecard	2025-09-19T08:53:51.2803199Z MTAfBgorBgEEAYO/MAEOBBEMD3JlZnMvaGVhZHMvbWFpbjAaBgorBgEEAYO/MAEP
+analysis	Run Scorecard	2025-09-19T08:53:51.2803651Z BAwMCjEwNTY4MDM0MzAwMAYKKwYBBAGDvzABEAQiDCBodHRwczovL2dpdGh1Yi5j
+analysis	Run Scorecard	2025-09-19T08:53:51.2804103Z b20vQ29kZXJEZWx0YUxBTjAZBgorBgEEAYO/MAERBAsMCTE1MjA0Mzc0NTBzBgor
+analysis	Run Scorecard	2025-09-19T08:53:51.2804549Z BgEEAYO/MAESBGUMY2h0dHBzOi8vZ2l0aHViLmNvbS9Db2RlckRlbHRhTEFOL2Np
+analysis	Run Scorecard	2025-09-19T08:53:51.2805004Z LW1hdHJpeC1zdGFydGVyLy5naXRodWIvd29ya2Zsb3dzL3Njb3JlY2FyZHMueW1s
+analysis	Run Scorecard	2025-09-19T08:53:51.2805449Z QHJlZnMvaGVhZHMvbWFpbjA4BgorBgEEAYO/MAETBCoMKDQzZTUzMTI5NzJlNjE2
+analysis	Run Scorecard	2025-09-19T08:53:51.2805907Z MTMzNDc3ZTI0YjllZGM5ZTRlZWUwODViYTEwIQYKKwYBBAGDvzABFAQTDBF3b3Jr
+analysis	Run Scorecard	2025-09-19T08:53:51.2806547Z Zmxvd19kaXNwYXRjaDBmBgorBgEEAYO/MAEVBFgMVmh0dHBzOi8vZ2l0aHViLmNv
+analysis	Run Scorecard	2025-09-19T08:53:51.2806998Z bS9Db2RlckRlbHRhTEFOL2NpLW1hdHJpeC1zdGFydGVyL2FjdGlvbnMvcnVucy8x
+analysis	Run Scorecard	2025-09-19T08:53:51.2807466Z Nzg1MzUyODA4MC9hdHRlbXB0cy8xMBYGCisGAQQBg78wARYECAwGcHVibGljMIGK
+analysis	Run Scorecard	2025-09-19T08:53:51.2807926Z BgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4py
+analysis	Run Scorecard	2025-09-19T08:53:51.2808388Z gC8p7o4AAAGZYS4HYgAABAMARzBFAiAEna3Ii39So59V3MWriXewCLGSWF1d04VI
+analysis	Run Scorecard	2025-09-19T08:53:51.2808840Z k3nTZreeNwIhAPEjNaZ+5o1txiV9GErSZaV905uNqXosyyIiYH+oqmo7MAoGCCqG
+analysis	Run Scorecard	2025-09-19T08:53:51.2809282Z SM49BAMDA2cAMGQCMErTBDCdLPnbo/2LDspjQbirOBJ0npxymCPeJI90ftJi8yzp
+analysis	Run Scorecard	2025-09-19T08:53:51.2809719Z /N1/ug58guDe+zUKTgIwf9can2d6+w+3x37rkDsZ4EmkN+V0xGPPB+gCkWk+4ZBX
+analysis	Run Scorecard	2025-09-19T08:53:51.2810047Z lc6JPxyB7nsy8HyQeeET
+analysis	Run Scorecard	2025-09-19T08:53:51.2810247Z -----END CERTIFICATE-----
+analysis	Run Scorecard	2025-09-19T08:53:51.2810381Z
+analysis	Run Scorecard	2025-09-19T08:53:51.2810477Z Wrote bundle to file /tmp/bundle3243875977
+analysis	Run Scorecard	2025-09-19T08:53:51.2810988Z MEUCIQCPlPASe4+Nv/szuDDzDDhxy8CqhuWz5yguzCF9rxdB+gIgCkbH3ZeNELca9ga1h49cvzOI60pla9YPKbFlN8GEmOg=
+analysis	Upload SARIF to code scanning	﻿2025-09-19T08:53:52.8711449Z ##[group]Run github/codeql-action/upload-sarif@v3
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8711771Z with:
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8711948Z   sarif_file: results.sarif
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8712274Z   checkout_path: /home/runner/work/ci-matrix-starter/ci-matrix-starter
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8712726Z   token: ***
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8712891Z   matrix: null
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8713082Z   wait-for-processing: true
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8713287Z ##[endgroup]
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5129060Z ##[group]Uploading code scanning results
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5129606Z Processing sarif files: ["results.sarif"]
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5140883Z Validating results.sarif
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5816082Z Warning: 'no file associated with this alert' is not a valid URI in 'instance.runs[1].results[0].locations[0].physicalLocation.artifactLocation.uri'.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5817363Z Warning: 'no file associated with this alert' is not a valid URI in 'instance.runs[1].results[1].locations[0].physicalLocation.artifactLocation.uri'.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5818246Z Warning: 'no file associated with this alert' is not a valid URI in 'instance.runs[2].results[0].locations[0].physicalLocation.artifactLocation.uri'.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5819167Z Warning: 'no file associated with this alert' is not a valid URI in 'instance.runs[2].results[1].locations[0].physicalLocation.artifactLocation.uri'.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5820065Z Warning: 'no file associated with this alert' is not a valid URI in 'instance.runs[2].results[2].locations[0].physicalLocation.artifactLocation.uri'.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5821475Z Warning: 'no file associated with this alert' is not a valid URI in 'instance.runs[2].results[3].locations[0].physicalLocation.artifactLocation.uri'.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5824547Z Adding fingerprints to SARIF file. See https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#providing-data-to-track-code-scanning-alerts-across-runs for more information.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.6092702Z Uploading results
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.8572396Z Successfully uploaded results
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.8573145Z ##[endgroup]
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.8578382Z ##[group]Waiting for processing to finish
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:54.0077653Z Analysis upload status is pending.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:59.1867210Z Analysis upload status is complete.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:59.1868388Z ##[endgroup]
+analysis	Post Upload SARIF to code scanning	﻿2025-09-19T08:53:59.3198088Z Post job cleanup.
+analysis	Post Upload SARIF to code scanning	2025-09-19T08:53:59.5133440Z ##[group]Uploading combined SARIF debug artifact
+analysis	Post Upload SARIF to code scanning	2025-09-19T08:53:59.5135443Z ##[endgroup]
+analysis	Post Run actions/checkout@v4	﻿2025-09-19T08:53:59.5266622Z Post job cleanup.
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6192380Z [command]/usr/bin/git version
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6245146Z git version 2.51.0
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6304139Z Temporarily overriding HOME='/home/runner/work/_temp/310edc28-a4e0-4e70-84cf-3b3916841469' before making global git config changes
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6305146Z Adding repository directory to the temporary git global config as a safe directory
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6316148Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/ci-matrix-starter/ci-matrix-starter
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6351622Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6385031Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6607993Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6640004Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+analysis	Complete job	﻿2025-09-19T08:53:59.6961946Z Cleaning up orphan processes

--- a/_ci_redfix/20250919-085657/scorecard-17853528080.tail.txt
+++ b/_ci_redfix/20250919-085657/scorecard-17853528080.tail.txt
@@ -1,0 +1,212 @@
+analysis	Run Scorecard	2025-09-19T08:53:39.5182099Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5182179Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5182248Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5182323Z                            "startLine": 1
+analysis	Run Scorecard	2025-09-19T08:53:39.5182393Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.5182473Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5182574Z                            "uri": "no file associated with this alert",
+analysis	Run Scorecard	2025-09-19T08:53:39.5182664Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.5182727Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.5182788Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5182848Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.5182913Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5182972Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.5183030Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.5183112Z                "ruleId": "FuzzingID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5183306Z                "ruleIndex": 4,
+analysis	Run Scorecard	2025-09-19T08:53:39.5183372Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5193269Z                   "text": "score is 0: project is not fuzzed:\nWarn: no OSSFuzz integration found: Follow the steps in https://github.com/google/oss-fuzz to integrate fuzzing for your project.\nOver time, try to add fuzzing for more functionalities of your project. (High effort)\nWarn: no OneFuzz integration found: Follow the steps in https://github.com/microsoft/onefuzz to start fuzzing for your project.\nOver time, try to add fuzzing for more functionalities of your project. (High effort)\nWarn: no GoBuiltInFuzzer integration found: Follow the steps in https://go.dev/doc/fuzz/ to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no PythonAtherisFuzzer integration found: Follow the steps in https://github.com/google/atheris to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no CLibFuzzer integration found: Follow the steps in https://llvm.org/docs/LibFuzzer.html to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no CppLibFuzzer integration found: Follow the steps in https://llvm.org/docs/LibFuzzer.html to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no SwiftLibFuzzer integration found: Follow the steps in https://google.github.io/oss-fuzz/getting-started/new-project-guide/swift-lang/ to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no RustCargoFuzzer integration found: Follow the steps in https://rust-fuzz.github.io/book/cargo-fuzz.html to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no JavaJazzerFuzzer integration found: Follow the steps in https://github.com/CodeIntelligenceTesting/jazzer to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)\nWarn: no ClusterFuzzLite integration found: Follow the steps in https://github.com/google/clusterfuzzlite to integrate fuzzing as part of CI.\nOver time, try to add fuzzing for more functionalities of your project. (High effort)\nWarn: no HaskellPropertyBasedTesting integration found: Use one of the following frameworks to fuzz your project:\nQuickCheck: https://hackage.haskell.org/package/QuickCheck\nhedgehog: https://hedgehog.qa/\nvalidity: https://github.com/NorfairKing/validity\nsmallcheck: https://hackage.haskell.org/package/smallcheck\nhspec: https://hspec.github.io/\ntasty: https://hackage.haskell.org/package/tasty (High effort)\nWarn: no TypeScriptPropertyBasedTesting integration found: Use fast-check: https://github.com/dubzzz/fast-check (High effort)\nWarn: no JavaScriptPropertyBasedTesting integration found: Use fast-check: https://github.com/dubzzz/fast-check (High effort)\nClick Remediation section below to solve this issue"
+analysis	Run Scorecard	2025-09-19T08:53:39.5193470Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.5193539Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5193604Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5193683Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5193750Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5193826Z                            "startLine": 1
+analysis	Run Scorecard	2025-09-19T08:53:39.5193891Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.5193972Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5194073Z                            "uri": "no file associated with this alert",
+analysis	Run Scorecard	2025-09-19T08:53:39.5194156Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.5194218Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.5194277Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5194341Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.5194399Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5194562Z             },
+analysis	Run Scorecard	2025-09-19T08:53:39.5194620Z             {
+analysis	Run Scorecard	2025-09-19T08:53:39.5194704Z                "ruleId": "MaintainedID",
+analysis	Run Scorecard	2025-09-19T08:53:39.5194772Z                "ruleIndex": 5,
+analysis	Run Scorecard	2025-09-19T08:53:39.5194836Z                "message": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5195502Z                   "text": "score is 0: repo was created 4 days ago, not enough maintenance history:\nWarn: repo was created in the last 90 days (Created at: 2025-09-14T20:43:38Z), please review its contents carefully\nClick Remediation section below to solve this issue"
+analysis	Run Scorecard	2025-09-19T08:53:39.5195638Z                },
+analysis	Run Scorecard	2025-09-19T08:53:39.5195704Z                "locations": [
+analysis	Run Scorecard	2025-09-19T08:53:39.5195770Z                   {
+analysis	Run Scorecard	2025-09-19T08:53:39.5195848Z                      "physicalLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5195915Z                         "region": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5195986Z                            "startLine": 1
+analysis	Run Scorecard	2025-09-19T08:53:39.5196054Z                         },
+analysis	Run Scorecard	2025-09-19T08:53:39.5196139Z                         "artifactLocation": {
+analysis	Run Scorecard	2025-09-19T08:53:39.5196331Z                            "uri": "no file associated with this alert",
+analysis	Run Scorecard	2025-09-19T08:53:39.5196418Z                            "uriBaseId": "%SRCROOT%"
+analysis	Run Scorecard	2025-09-19T08:53:39.5196480Z                         }
+analysis	Run Scorecard	2025-09-19T08:53:39.5196540Z                      }
+analysis	Run Scorecard	2025-09-19T08:53:39.5196604Z                   }
+analysis	Run Scorecard	2025-09-19T08:53:39.5196663Z                ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5196722Z             }
+analysis	Run Scorecard	2025-09-19T08:53:39.5196779Z          ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5196848Z       }
+analysis	Run Scorecard	2025-09-19T08:53:39.5196908Z    ]
+analysis	Run Scorecard	2025-09-19T08:53:39.5196969Z }
+analysis	Run Scorecard	2025-09-19T08:53:39.5197784Z EnvGithubAuthToken: GITHUB_AUTH_TOKEN ***
+analysis	Run Scorecard	2025-09-19T08:53:39.5197866Z Scorecard options:
+analysis	Run Scorecard	2025-09-19T08:53:39.5197928Z Ref: HEAD
+analysis	Run Scorecard	2025-09-19T08:53:39.5198033Z Repository: CoderDeltaLAN/ci-matrix-starter
+analysis	Run Scorecard	2025-09-19T08:53:39.5198101Z Local:
+analysis	Run Scorecard	2025-09-19T08:53:39.5198169Z Format: json
+analysis	Run Scorecard	2025-09-19T08:53:39.5198235Z Policy file:
+analysis	Run Scorecard	2025-09-19T08:53:39.5198239Z
+analysis	Run Scorecard	2025-09-19T08:53:39.5198327Z Event / repo information:
+analysis	Run Scorecard	2025-09-19T08:53:39.5198418Z Event file: /github/workflow/event.json
+analysis	Run Scorecard	2025-09-19T08:53:39.5198498Z Event name: workflow_dispatch
+analysis	Run Scorecard	2025-09-19T08:53:39.5198570Z Fork repository: false
+analysis	Run Scorecard	2025-09-19T08:53:39.5198652Z Private repository: false
+analysis	Run Scorecard	2025-09-19T08:53:39.5198729Z Publication enabled: false
+analysis	Run Scorecard	2025-09-19T08:53:39.5198797Z Default branch: main
+analysis	Run Scorecard	2025-09-19T08:53:50.3953918Z Using payload from: results.json
+analysis	Run Scorecard	2025-09-19T08:53:50.3954374Z Generating ephemeral keys...
+analysis	Run Scorecard	2025-09-19T08:53:50.4014871Z {"date":"2025-09-19T08:53:39Z","repo":{"name":"github.com/CoderDeltaLAN/ci-matrix-starter","commit":"43e5312972e616133477e24b9edc9e4eee085ba1"},"scorecard":{"version":"v4.13.1","commit":"49c0eed3a423f00c872b5c3c9f1bbca9e8aae799"},"score":5.6,"checks":[{"details":null,"score":10,"reason":"no binaries found in the repo","name":"Binary-Artifacts","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#binary-artifacts","short":"Determines if the project has generated executable (binary) artifacts in the source repository."}},{"details":null,"score":-1,"reason":"internal error: error during branchesHandler.setup: internal error: githubv4.Query: Resource not accessible by integration","name":"Branch-Protection","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#branch-protection","short":"Determines if the default and release branches are protected with GitHub's branch protection settings."}},{"details":null,"score":10,"reason":"28 out of 28 merged PRs checked by a CI test -- score normalized to 10","name":"CI-Tests","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#ci-tests","short":"Determines if the project runs tests before pull requests are merged."}},{"details":null,"score":0,"reason":"no effort to earn an OpenSSF best practices badge detected","name":"CII-Best-Practices","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#cii-best-practices","short":"Determines if the project has an OpenSSF (formerly CII) Best Practices Badge."}},{"details":null,"score":6,"reason":"found 11 unreviewed changesets out of 30 -- score normalized to 6","name":"Code-Review","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#code-review","short":"Determines if the project requires human code review before pull requests (aka merge requests) are merged."}},{"details":["Info: contributors work for coderdeltalan (independent oss maintainer)"],"score":3,"reason":"1 different organizations found -- score normalized to 3","name":"Contributors","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#contributors","short":"Determines if the project has a set of contributors from multiple organizations (e.g., companies)."}},{"details":null,"score":10,"reason":"no dangerous workflow patterns detected","name":"Dangerous-Workflow","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#dangerous-workflow","short":"Determines if the project's GitHub Action workflows avoid dangerous patterns."}},{"details":["Warn: tool 'RenovateBot' is not used: Follow the instructions from https://docs.renovatebot.com/configuration-options/. (Low effort)","Warn: tool 'Dependabot' is not used: Follow the instructions from https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates. (Low effort)","Warn: tool 'PyUp' is not used: Follow the instructions from https://docs.pyup.io/docs. (Low effort)","Warn: tool 'Sonatype Lift' is not used: Follow the instructions from https://help.sonatype.com/lift/getting-started. (Low effort)"],"score":0,"reason":"no update tool detected","name":"Dependency-Update-Tool","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#dependency-update-tool","short":"Determines if the project uses a dependency update tool."}},{"details":["Warn: no OSSFuzz integration found: Follow the steps in https://github.com/google/oss-fuzz to integrate fuzzing for your project.\nOver time, try to add fuzzing for more functionalities of your project. (High effort)","Warn: no OneFuzz integration found: Follow the steps in https://github.com/microsoft/onefuzz to start fuzzing for your project.\nOver time, try to add fuzzing for more functionalities of your project. (High effort)","Warn: no GoBuiltInFuzzer integration found: Follow the steps in https://go.dev/doc/fuzz/ to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no PythonAtherisFuzzer integration found: Follow the steps in https://github.com/google/atheris to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no CLibFuzzer integration found: Follow the steps in https://llvm.org/docs/LibFuzzer.html to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no CppLibFuzzer integration found: Follow the steps in https://llvm.org/docs/LibFuzzer.html to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no SwiftLibFuzzer integration found: Follow the steps in https://google.github.io/oss-fuzz/getting-started/new-project-guide/swift-lang/ to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no RustCargoFuzzer integration found: Follow the steps in https://rust-fuzz.github.io/book/cargo-fuzz.html to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no JavaJazzerFuzzer integration found: Follow the steps in https://github.com/CodeIntelligenceTesting/jazzer to enable fuzzing on your project.\nOver time, try to add fuzzing for more functionalities of your project. (Medium effort)","Warn: no ClusterFuzzLite integration found: Follow the steps in https://github.com/google/clusterfuzzlite to integrate fuzzing as part of CI.\nOver time, try to add fuzzing for more functionalities of your project. (High effort)","Warn: no HaskellPropertyBasedTesting integration found: Use one of the following frameworks to fuzz your project:\nQuickCheck: https://hackage.haskell.org/package/QuickCheck\nhedgehog: https://hedgehog.qa/\nvalidity: https://github.com/NorfairKing/validity\nsmallcheck: https://hackage.haskell.org/package/smallcheck\nhspec: https://hspec.github.io/\ntasty: https://hackage.haskell.org/package/tasty (High effort)","Warn: no TypeScriptPropertyBasedTesting integration found: Use fast-check: https://github.com/dubzzz/fast-check (High effort)","Warn: no JavaScriptPropertyBasedTesting integration found: Use fast-check: https://github.com/dubzzz/fast-check (High effort)"],"score":0,"reason":"project is not fuzzed","name":"Fuzzing","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#fuzzing","short":"Determines if the project uses fuzzing."}},{"details":null,"score":0,"reason":"license file not detected","name":"License","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#license","short":"Determines if the project has defined a license."}},{"details":["Warn: repo was created in the last 90 days (Created at: 2025-09-14T20:43:38Z), please review its contents carefully"],"score":0,"reason":"repo was created 4 days ago, not enough maintenance history","name":"Maintained","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#maintained","short":"Determines if the project is \"actively maintained\"."}},{"details":["Info: GitHub/GitLab publishing workflow used in run https://api.github.com/repos/CoderDeltaLAN/ci-matrix-starter/actions/runs/17849131652: .github/workflows/ghcr-publish.yml:10"],"score":10,"reason":"publishing workflow detected","name":"Packaging","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#packaging","short":"Determines if the project is published as a package that others can easily download, install, easily update, and uninstall."}},{"details":null,"score":-1,"reason":"internal error: internal error: unable to determine OS for job: node${{ matrix.node }} • ${{ matrix.os }}","name":"Pinned-Dependencies","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#pinned-dependencies","short":"Determines if the project has declared and pinned the dependencies of its build process."}},{"details":["Info: all commits (28) are checked with a SAST tool","Info: SAST tool detected: CodeQL"],"score":10,"reason":"SAST tool is run on all commits","name":"SAST","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#sast","short":"Determines if the project uses static code analysis."}},{"details":["Info: security policy file detected: SECURITY.md:1","Info: Found linked content: SECURITY.md:1","Info: Found disclosure, vulnerability, and/or timelines in security policy: SECURITY.md:1","Info: Found text in security policy: SECURITY.md:1"],"score":10,"reason":"security policy file detected","name":"Security-Policy","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#security-policy","short":"Determines if the project has published a security policy."}},{"details":["Warn: no GitHub releases found"],"score":-1,"reason":"no releases found","name":"Signed-Releases","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#signed-releases","short":"Determines if the project cryptographically signs release artifacts."}},{"details":["Info: topLevel 'contents' permission set to 'read': .github/workflows/build.yml:9","Warn: topLevel 'security-events' permission set to 'write': .github/workflows/build.yml:10: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/build.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Info: topLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:12","Warn: topLevel 'security-events' permission set to 'write': .github/workflows/codeql.yml:13: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/codeql.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Warn: topLevel 'contents' permission set to 'write': .github/workflows/dependabot-auto-merge.yml:11: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/dependabot-auto-merge.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Info: topLevel 'contents' permission set to 'read': .github/workflows/ghcr-publish.yml:7","Warn: topLevel 'packages' permission set to 'write': .github/workflows/ghcr-publish.yml:8: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/ghcr-publish.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Info: topLevel 'contents' permission set to 'read': .github/workflows/labeler.yml:6","Info: topLevel 'contents' permission set to 'read': .github/workflows/npm-gpr.yml:7","Warn: topLevel 'packages' permission set to 'write': .github/workflows/npm-gpr.yml:8: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/npm-gpr.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Info: topLevel 'contents' permission set to 'read': .github/workflows/publish-pypi.yml:8","Info: topLevel 'contents' permission set to 'read': .github/workflows/py-ci.yml:20","Warn: topLevel 'contents' permission set to 'write': .github/workflows/release-drafter.yml:10: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/release-drafter.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Warn: topLevel 'contents' permission set to 'write': .github/workflows/release-sbom.yml:7: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/release-sbom.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Info: topLevel 'contents' permission set to 'read': .github/workflows/scorecards.yml:10","Info: jobLevel 'contents' permission set to 'read': .github/workflows/scorecards.yml:22","Warn: topLevel 'statuses' permission set to 'write': .github/workflows/semantic-pr.yml:7: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/semantic-pr.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Warn: no topLevel permission defined: .github/workflows/supply-chain.yml:1: Visit https://app.stepsecurity.io/secureworkflow/CoderDeltaLAN/ci-matrix-starter/supply-chain.yml/main?enable=permissions\nTick the 'Restrict permissions for GITHUB_TOKEN'\nUntick other options\nNOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)","Warn: jobLevel 'contents' permission set to 'write': .github/workflows/supply-chain.yml:12: Verify which permissions are needed and consider whether you can reduce them. (High effort)","Info: topLevel 'contents' permission set to 'read': .github/workflows/ts-ci.yml:24"],"score":0,"reason":"detected GitHub workflow tokens with excessive permissions","name":"Token-Permissions","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#token-permissions","short":"Determines if the project's workflows follow the principle of least privilege."}},{"details":null,"score":10,"reason":"no vulnerabilities detected","name":"Vulnerabilities","documentation":{"url":"https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#vulnerabilities","short":"Determines if the project has open, known unfixed vulnerabilities."}}],"metadata":null}
+analysis	Run Scorecard	2025-09-19T08:53:50.4788379Z Retrieving signed certificate...
+analysis	Run Scorecard	2025-09-19T08:53:50.9265801Z Successfully verified SCT...
+analysis	Run Scorecard	2025-09-19T08:53:50.9266537Z
+analysis	Run Scorecard	2025-09-19T08:53:50.9268640Z 	The sigstore service, hosted by sigstore a Series of LF Projects, LLC, is provided pursuant to the Hosted Project Tools Terms of Use, available at https://lfprojects.org/policies/hosted-project-tools-terms-of-use/.
+analysis	Run Scorecard	2025-09-19T08:53:50.9270915Z 	Note that if your submission includes personal data associated with this signed artifact, it will be part of an immutable record.
+analysis	Run Scorecard	2025-09-19T08:53:50.9272564Z 	This may include the email address associated with the account with which you authenticate your contractual Agreement.
+analysis	Run Scorecard	2025-09-19T08:53:50.9274904Z 	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later, and is subject to the Immutable Record notice at https://lfprojects.org/policies/hosted-project-tools-immutable-records/.
+analysis	Run Scorecard	2025-09-19T08:53:50.9276869Z
+analysis	Run Scorecard	2025-09-19T08:53:50.9277947Z By typing 'y', you attest that (1) you are not submitting the personal data of any other person; and (2) you understand and agree to the statement and the Agreement terms at the URLs listed above.
+analysis	Run Scorecard	2025-09-19T08:53:50.9279359Z using ephemeral certificate:
+analysis	Run Scorecard	2025-09-19T08:53:50.9279821Z -----BEGIN CERTIFICATE-----
+analysis	Run Scorecard	2025-09-19T08:53:50.9280562Z MIIHKzCCBrKgAwIBAgIUBwLgLAGsCmZ0QQo+0Gy5SuZeipEwCgYIKoZIzj0EAwMw
+analysis	Run Scorecard	2025-09-19T08:53:50.9281479Z NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
+analysis	Run Scorecard	2025-09-19T08:53:50.9282336Z cm1lZGlhdGUwHhcNMjUwOTE5MDg1MzUwWhcNMjUwOTE5MDkwMzUwWjAAMFkwEwYH
+analysis	Run Scorecard	2025-09-19T08:53:50.9282828Z KoZIzj0CAQYIKoZIzj0DAQcDQgAE+j/m2ZaVh33J/VeQrBO8Ik6vb1H7HJPTLGJU
+analysis	Run Scorecard	2025-09-19T08:53:50.9283274Z X0xJ2PmV1+f5HUMKT/CeyMiJhBhO74cReH76IcgY7QBNN52MF6OCBdEwggXNMA4G
+analysis	Run Scorecard	2025-09-19T08:53:50.9283736Z A1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUjcEf
+analysis	Run Scorecard	2025-09-19T08:53:50.9284208Z pP36zbVudjmPRSbGKYw0u4IwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y
+analysis	Run Scorecard	2025-09-19T08:53:50.9284684Z ZD8wcQYDVR0RAQH/BGcwZYZjaHR0cHM6Ly9naXRodWIuY29tL0NvZGVyRGVsdGFM
+analysis	Run Scorecard	2025-09-19T08:53:50.9285143Z QU4vY2ktbWF0cml4LXN0YXJ0ZXIvLmdpdGh1Yi93b3JrZmxvd3Mvc2NvcmVjYXJk
+analysis	Run Scorecard	2025-09-19T08:53:50.9285613Z cy55bWxAcmVmcy9oZWFkcy9tYWluMDkGCisGAQQBg78wAQEEK2h0dHBzOi8vdG9r
+analysis	Run Scorecard	2025-09-19T08:53:50.9286078Z ZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVudC5jb20wHwYKKwYBBAGDvzABAgQR
+analysis	Run Scorecard	2025-09-19T08:53:50.9286688Z d29ya2Zsb3dfZGlzcGF0Y2gwNgYKKwYBBAGDvzABAwQoNDNlNTMxMjk3MmU2MTYx
+analysis	Run Scorecard	2025-09-19T08:53:50.9287145Z MzM0NzdlMjRiOWVkYzllNGVlZTA4NWJhMTAfBgorBgEEAYO/MAEEBBFPcGVuU1NG
+analysis	Run Scorecard	2025-09-19T08:53:50.9287825Z IFNjb3JlY2FyZDAtBgorBgEEAYO/MAEFBB9Db2RlckRlbHRhTEFOL2NpLW1hdHJp
+analysis	Run Scorecard	2025-09-19T08:53:50.9288281Z eC1zdGFydGVyMB0GCisGAQQBg78wAQYED3JlZnMvaGVhZHMvbWFpbjA7BgorBgEE
+analysis	Run Scorecard	2025-09-19T08:53:50.9288740Z AYO/MAEIBC0MK2h0dHBzOi8vdG9rZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVu
+analysis	Run Scorecard	2025-09-19T08:53:50.9289216Z dC5jb20wcwYKKwYBBAGDvzABCQRlDGNodHRwczovL2dpdGh1Yi5jb20vQ29kZXJE
+analysis	Run Scorecard	2025-09-19T08:53:50.9289683Z ZWx0YUxBTi9jaS1tYXRyaXgtc3RhcnRlci8uZ2l0aHViL3dvcmtmbG93cy9zY29y
+analysis	Run Scorecard	2025-09-19T08:53:50.9290152Z ZWNhcmRzLnltbEByZWZzL2hlYWRzL21haW4wOAYKKwYBBAGDvzABCgQqDCg0M2U1
+analysis	Run Scorecard	2025-09-19T08:53:50.9290762Z MzEyOTcyZTYxNjEzMzQ3N2UyNGI5ZWRjOWU0ZWVlMDg1YmExMB0GCisGAQQBg78w
+analysis	Run Scorecard	2025-09-19T08:53:50.9291223Z AQsEDwwNZ2l0aHViLWhvc3RlZDBCBgorBgEEAYO/MAEMBDQMMmh0dHBzOi8vZ2l0
+analysis	Run Scorecard	2025-09-19T08:53:50.9291682Z aHViLmNvbS9Db2RlckRlbHRhTEFOL2NpLW1hdHJpeC1zdGFydGVyMDgGCisGAQQB
+analysis	Run Scorecard	2025-09-19T08:53:50.9292148Z g78wAQ0EKgwoNDNlNTMxMjk3MmU2MTYxMzM0NzdlMjRiOWVkYzllNGVlZTA4NWJh
+analysis	Run Scorecard	2025-09-19T08:53:50.9292606Z MTAfBgorBgEEAYO/MAEOBBEMD3JlZnMvaGVhZHMvbWFpbjAaBgorBgEEAYO/MAEP
+analysis	Run Scorecard	2025-09-19T08:53:50.9293074Z BAwMCjEwNTY4MDM0MzAwMAYKKwYBBAGDvzABEAQiDCBodHRwczovL2dpdGh1Yi5j
+analysis	Run Scorecard	2025-09-19T08:53:50.9293522Z b20vQ29kZXJEZWx0YUxBTjAZBgorBgEEAYO/MAERBAsMCTE1MjA0Mzc0NTBzBgor
+analysis	Run Scorecard	2025-09-19T08:53:50.9293968Z BgEEAYO/MAESBGUMY2h0dHBzOi8vZ2l0aHViLmNvbS9Db2RlckRlbHRhTEFOL2Np
+analysis	Run Scorecard	2025-09-19T08:53:50.9294421Z LW1hdHJpeC1zdGFydGVyLy5naXRodWIvd29ya2Zsb3dzL3Njb3JlY2FyZHMueW1s
+analysis	Run Scorecard	2025-09-19T08:53:50.9294873Z QHJlZnMvaGVhZHMvbWFpbjA4BgorBgEEAYO/MAETBCoMKDQzZTUzMTI5NzJlNjE2
+analysis	Run Scorecard	2025-09-19T08:53:50.9295324Z MTMzNDc3ZTI0YjllZGM5ZTRlZWUwODViYTEwIQYKKwYBBAGDvzABFAQTDBF3b3Jr
+analysis	Run Scorecard	2025-09-19T08:53:50.9295786Z Zmxvd19kaXNwYXRjaDBmBgorBgEEAYO/MAEVBFgMVmh0dHBzOi8vZ2l0aHViLmNv
+analysis	Run Scorecard	2025-09-19T08:53:50.9296347Z bS9Db2RlckRlbHRhTEFOL2NpLW1hdHJpeC1zdGFydGVyL2FjdGlvbnMvcnVucy8x
+analysis	Run Scorecard	2025-09-19T08:53:50.9296815Z Nzg1MzUyODA4MC9hdHRlbXB0cy8xMBYGCisGAQQBg78wARYECAwGcHVibGljMIGK
+analysis	Run Scorecard	2025-09-19T08:53:50.9297282Z BgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4py
+analysis	Run Scorecard	2025-09-19T08:53:50.9297739Z gC8p7o4AAAGZYS4HYgAABAMARzBFAiAEna3Ii39So59V3MWriXewCLGSWF1d04VI
+analysis	Run Scorecard	2025-09-19T08:53:50.9298204Z k3nTZreeNwIhAPEjNaZ+5o1txiV9GErSZaV905uNqXosyyIiYH+oqmo7MAoGCCqG
+analysis	Run Scorecard	2025-09-19T08:53:50.9298648Z SM49BAMDA2cAMGQCMErTBDCdLPnbo/2LDspjQbirOBJ0npxymCPeJI90ftJi8yzp
+analysis	Run Scorecard	2025-09-19T08:53:50.9299084Z /N1/ug58guDe+zUKTgIwf9can2d6+w+3x37rkDsZ4EmkN+V0xGPPB+gCkWk+4ZBX
+analysis	Run Scorecard	2025-09-19T08:53:50.9299420Z lc6JPxyB7nsy8HyQeeET
+analysis	Run Scorecard	2025-09-19T08:53:50.9299610Z -----END CERTIFICATE-----
+analysis	Run Scorecard	2025-09-19T08:53:50.9299744Z
+analysis	Run Scorecard	2025-09-19T08:53:51.2787863Z tlog entry created with index: 537222745
+analysis	Run Scorecard	2025-09-19T08:53:51.2788744Z using ephemeral certificate:
+analysis	Run Scorecard	2025-09-19T08:53:51.2789207Z -----BEGIN CERTIFICATE-----
+analysis	Run Scorecard	2025-09-19T08:53:51.2789915Z MIIHKzCCBrKgAwIBAgIUBwLgLAGsCmZ0QQo+0Gy5SuZeipEwCgYIKoZIzj0EAwMw
+analysis	Run Scorecard	2025-09-19T08:53:51.2790903Z NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
+analysis	Run Scorecard	2025-09-19T08:53:51.2791771Z cm1lZGlhdGUwHhcNMjUwOTE5MDg1MzUwWhcNMjUwOTE5MDkwMzUwWjAAMFkwEwYH
+analysis	Run Scorecard	2025-09-19T08:53:51.2792563Z KoZIzj0CAQYIKoZIzj0DAQcDQgAE+j/m2ZaVh33J/VeQrBO8Ik6vb1H7HJPTLGJU
+analysis	Run Scorecard	2025-09-19T08:53:51.2793131Z X0xJ2PmV1+f5HUMKT/CeyMiJhBhO74cReH76IcgY7QBNN52MF6OCBdEwggXNMA4G
+analysis	Run Scorecard	2025-09-19T08:53:51.2793722Z A1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUjcEf
+analysis	Run Scorecard	2025-09-19T08:53:51.2794323Z pP36zbVudjmPRSbGKYw0u4IwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y
+analysis	Run Scorecard	2025-09-19T08:53:51.2794897Z ZD8wcQYDVR0RAQH/BGcwZYZjaHR0cHM6Ly9naXRodWIuY29tL0NvZGVyRGVsdGFM
+analysis	Run Scorecard	2025-09-19T08:53:51.2795450Z QU4vY2ktbWF0cml4LXN0YXJ0ZXIvLmdpdGh1Yi93b3JrZmxvd3Mvc2NvcmVjYXJk
+analysis	Run Scorecard	2025-09-19T08:53:51.2796028Z cy55bWxAcmVmcy9oZWFkcy9tYWluMDkGCisGAQQBg78wAQEEK2h0dHBzOi8vdG9r
+analysis	Run Scorecard	2025-09-19T08:53:51.2796870Z ZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVudC5jb20wHwYKKwYBBAGDvzABAgQR
+analysis	Run Scorecard	2025-09-19T08:53:51.2797392Z d29ya2Zsb3dfZGlzcGF0Y2gwNgYKKwYBBAGDvzABAwQoNDNlNTMxMjk3MmU2MTYx
+analysis	Run Scorecard	2025-09-19T08:53:51.2797841Z MzM0NzdlMjRiOWVkYzllNGVlZTA4NWJhMTAfBgorBgEEAYO/MAEEBBFPcGVuU1NG
+analysis	Run Scorecard	2025-09-19T08:53:51.2798277Z IFNjb3JlY2FyZDAtBgorBgEEAYO/MAEFBB9Db2RlckRlbHRhTEFOL2NpLW1hdHJp
+analysis	Run Scorecard	2025-09-19T08:53:51.2798719Z eC1zdGFydGVyMB0GCisGAQQBg78wAQYED3JlZnMvaGVhZHMvbWFpbjA7BgorBgEE
+analysis	Run Scorecard	2025-09-19T08:53:51.2799166Z AYO/MAEIBC0MK2h0dHBzOi8vdG9rZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVu
+analysis	Run Scorecard	2025-09-19T08:53:51.2799866Z dC5jb20wcwYKKwYBBAGDvzABCQRlDGNodHRwczovL2dpdGh1Yi5jb20vQ29kZXJE
+analysis	Run Scorecard	2025-09-19T08:53:51.2800326Z ZWx0YUxBTi9jaS1tYXRyaXgtc3RhcnRlci8uZ2l0aHViL3dvcmtmbG93cy9zY29y
+analysis	Run Scorecard	2025-09-19T08:53:51.2800788Z ZWNhcmRzLnltbEByZWZzL2hlYWRzL21haW4wOAYKKwYBBAGDvzABCgQqDCg0M2U1
+analysis	Run Scorecard	2025-09-19T08:53:51.2801256Z MzEyOTcyZTYxNjEzMzQ3N2UyNGI5ZWRjOWU0ZWVlMDg1YmExMB0GCisGAQQBg78w
+analysis	Run Scorecard	2025-09-19T08:53:51.2801716Z AQsEDwwNZ2l0aHViLWhvc3RlZDBCBgorBgEEAYO/MAEMBDQMMmh0dHBzOi8vZ2l0
+analysis	Run Scorecard	2025-09-19T08:53:51.2802291Z aHViLmNvbS9Db2RlckRlbHRhTEFOL2NpLW1hdHJpeC1zdGFydGVyMDgGCisGAQQB
+analysis	Run Scorecard	2025-09-19T08:53:51.2802749Z g78wAQ0EKgwoNDNlNTMxMjk3MmU2MTYxMzM0NzdlMjRiOWVkYzllNGVlZTA4NWJh
+analysis	Run Scorecard	2025-09-19T08:53:51.2803199Z MTAfBgorBgEEAYO/MAEOBBEMD3JlZnMvaGVhZHMvbWFpbjAaBgorBgEEAYO/MAEP
+analysis	Run Scorecard	2025-09-19T08:53:51.2803651Z BAwMCjEwNTY4MDM0MzAwMAYKKwYBBAGDvzABEAQiDCBodHRwczovL2dpdGh1Yi5j
+analysis	Run Scorecard	2025-09-19T08:53:51.2804103Z b20vQ29kZXJEZWx0YUxBTjAZBgorBgEEAYO/MAERBAsMCTE1MjA0Mzc0NTBzBgor
+analysis	Run Scorecard	2025-09-19T08:53:51.2804549Z BgEEAYO/MAESBGUMY2h0dHBzOi8vZ2l0aHViLmNvbS9Db2RlckRlbHRhTEFOL2Np
+analysis	Run Scorecard	2025-09-19T08:53:51.2805004Z LW1hdHJpeC1zdGFydGVyLy5naXRodWIvd29ya2Zsb3dzL3Njb3JlY2FyZHMueW1s
+analysis	Run Scorecard	2025-09-19T08:53:51.2805449Z QHJlZnMvaGVhZHMvbWFpbjA4BgorBgEEAYO/MAETBCoMKDQzZTUzMTI5NzJlNjE2
+analysis	Run Scorecard	2025-09-19T08:53:51.2805907Z MTMzNDc3ZTI0YjllZGM5ZTRlZWUwODViYTEwIQYKKwYBBAGDvzABFAQTDBF3b3Jr
+analysis	Run Scorecard	2025-09-19T08:53:51.2806547Z Zmxvd19kaXNwYXRjaDBmBgorBgEEAYO/MAEVBFgMVmh0dHBzOi8vZ2l0aHViLmNv
+analysis	Run Scorecard	2025-09-19T08:53:51.2806998Z bS9Db2RlckRlbHRhTEFOL2NpLW1hdHJpeC1zdGFydGVyL2FjdGlvbnMvcnVucy8x
+analysis	Run Scorecard	2025-09-19T08:53:51.2807466Z Nzg1MzUyODA4MC9hdHRlbXB0cy8xMBYGCisGAQQBg78wARYECAwGcHVibGljMIGK
+analysis	Run Scorecard	2025-09-19T08:53:51.2807926Z BgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4py
+analysis	Run Scorecard	2025-09-19T08:53:51.2808388Z gC8p7o4AAAGZYS4HYgAABAMARzBFAiAEna3Ii39So59V3MWriXewCLGSWF1d04VI
+analysis	Run Scorecard	2025-09-19T08:53:51.2808840Z k3nTZreeNwIhAPEjNaZ+5o1txiV9GErSZaV905uNqXosyyIiYH+oqmo7MAoGCCqG
+analysis	Run Scorecard	2025-09-19T08:53:51.2809282Z SM49BAMDA2cAMGQCMErTBDCdLPnbo/2LDspjQbirOBJ0npxymCPeJI90ftJi8yzp
+analysis	Run Scorecard	2025-09-19T08:53:51.2809719Z /N1/ug58guDe+zUKTgIwf9can2d6+w+3x37rkDsZ4EmkN+V0xGPPB+gCkWk+4ZBX
+analysis	Run Scorecard	2025-09-19T08:53:51.2810047Z lc6JPxyB7nsy8HyQeeET
+analysis	Run Scorecard	2025-09-19T08:53:51.2810247Z -----END CERTIFICATE-----
+analysis	Run Scorecard	2025-09-19T08:53:51.2810381Z
+analysis	Run Scorecard	2025-09-19T08:53:51.2810477Z Wrote bundle to file /tmp/bundle3243875977
+analysis	Run Scorecard	2025-09-19T08:53:51.2810988Z MEUCIQCPlPASe4+Nv/szuDDzDDhxy8CqhuWz5yguzCF9rxdB+gIgCkbH3ZeNELca9ga1h49cvzOI60pla9YPKbFlN8GEmOg=
+analysis	Upload SARIF to code scanning	﻿2025-09-19T08:53:52.8711449Z ##[group]Run github/codeql-action/upload-sarif@v3
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8711771Z with:
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8711948Z   sarif_file: results.sarif
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8712274Z   checkout_path: /home/runner/work/ci-matrix-starter/ci-matrix-starter
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8712726Z   token: ***
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8712891Z   matrix: null
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8713082Z   wait-for-processing: true
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:52.8713287Z ##[endgroup]
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5129060Z ##[group]Uploading code scanning results
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5129606Z Processing sarif files: ["results.sarif"]
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5140883Z Validating results.sarif
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5816082Z Warning: 'no file associated with this alert' is not a valid URI in 'instance.runs[1].results[0].locations[0].physicalLocation.artifactLocation.uri'.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5817363Z Warning: 'no file associated with this alert' is not a valid URI in 'instance.runs[1].results[1].locations[0].physicalLocation.artifactLocation.uri'.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5818246Z Warning: 'no file associated with this alert' is not a valid URI in 'instance.runs[2].results[0].locations[0].physicalLocation.artifactLocation.uri'.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5819167Z Warning: 'no file associated with this alert' is not a valid URI in 'instance.runs[2].results[1].locations[0].physicalLocation.artifactLocation.uri'.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5820065Z Warning: 'no file associated with this alert' is not a valid URI in 'instance.runs[2].results[2].locations[0].physicalLocation.artifactLocation.uri'.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5821475Z Warning: 'no file associated with this alert' is not a valid URI in 'instance.runs[2].results[3].locations[0].physicalLocation.artifactLocation.uri'.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.5824547Z Adding fingerprints to SARIF file. See https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#providing-data-to-track-code-scanning-alerts-across-runs for more information.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.6092702Z Uploading results
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.8572396Z Successfully uploaded results
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.8573145Z ##[endgroup]
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:53.8578382Z ##[group]Waiting for processing to finish
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:54.0077653Z Analysis upload status is pending.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:59.1867210Z Analysis upload status is complete.
+analysis	Upload SARIF to code scanning	2025-09-19T08:53:59.1868388Z ##[endgroup]
+analysis	Post Upload SARIF to code scanning	﻿2025-09-19T08:53:59.3198088Z Post job cleanup.
+analysis	Post Upload SARIF to code scanning	2025-09-19T08:53:59.5133440Z ##[group]Uploading combined SARIF debug artifact
+analysis	Post Upload SARIF to code scanning	2025-09-19T08:53:59.5135443Z ##[endgroup]
+analysis	Post Run actions/checkout@v4	﻿2025-09-19T08:53:59.5266622Z Post job cleanup.
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6192380Z [command]/usr/bin/git version
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6245146Z git version 2.51.0
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6304139Z Temporarily overriding HOME='/home/runner/work/_temp/310edc28-a4e0-4e70-84cf-3b3916841469' before making global git config changes
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6305146Z Adding repository directory to the temporary git global config as a safe directory
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6316148Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/ci-matrix-starter/ci-matrix-starter
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6351622Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6385031Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6607993Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+analysis	Post Run actions/checkout@v4	2025-09-19T08:53:59.6640004Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+analysis	Complete job	﻿2025-09-19T08:53:59.6961946Z Cleaning up orphan processes


### PR DESCRIPTION
Verified locally: hooks + actionlint green. Adds id-token:write and security-events:write. Uploads SARIF; no external publish.