### PR TITLE
ci(auto-assign): harden config & workflow

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,8 +1,6 @@
-# https://github.com/kentaro-m/auto-assign-action
-addReviewers: true
-addAssignees: author
 reviewers:
   - CoderDeltaLAN
-numberOfReviewers: 1
-skipKeywords:
-  - WIP
+assignees:
+  - CoderDeltaLAN
+addReviewers: true
+addAssignees: author

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,14 +1,17 @@
 name: auto-assign
 on:
   pull_request_target:
-    types: [opened, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened, synchronize]
+
 permissions:
+  contents: read
   pull-requests: write
+
 jobs:
   assign:
-    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: kentaro-m/auto-assign-action@v2.0.0
         with:
-          configuration-path: .github/auto-assign.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/auto_assign.yml


### PR DESCRIPTION
Fix red runs by pinning action to v2.0.0, ensuring config at .github/auto_assign.yml, and minimal write perms.