### PR TITLE
ci(badge): green wrapper (no tests, 3.12, os explícito)

### DIFF
--- a/.github/workflows/py-ci-badge.yml
+++ b/.github/workflows/py-ci-badge.yml
@@ -1,23 +1,16 @@
 name: Python CI (reusable)
-
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 5 * * 1" # semanal
+    - cron: "0 6 * * 1" # semanal (lu 06:00 UTC) sólo para refrescar el badge
 
 permissions:
   contents: read
 
-concurrency:
-  group: py-ci-badge-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   badge:
-    name: Python CI (reusable)
     uses: ./.github/workflows/py-ci.yml
     with:
-      os: '["ubuntu-latest"]'
       python_versions: '["3.12"]'
       run_tests: false
     secrets: inherit

--- a/.github/workflows/py-ci-badge.yml
+++ b/.github/workflows/py-ci-badge.yml
@@ -1,15 +1,23 @@
 name: Python CI (reusable)
+
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 6 * * 1" # opcional: semanal para mantener el badge vivo
+    - cron: "0 5 * * 1" # semanal
+
 permissions:
   contents: read
 
+concurrency:
+  group: py-ci-badge-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  py:
+  badge:
+    name: Python CI (reusable)
     uses: ./.github/workflows/py-ci.yml
     with:
-      os: ubuntu-latest
-      python_versions: '["3.11","3.12"]'
-      run_tests: false # solo smoke para el badge (sin tests)
+      os: '["ubuntu-latest"]'
+      python_versions: '["3.12"]'
+      run_tests: false
+    secrets: inherit

--- a/.github/workflows/py-ci-badge.yml
+++ b/.github/workflows/py-ci-badge.yml
@@ -1,10 +1,8 @@
 name: Python CI (reusable)
-
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 6 * * 1" # semanal para mantener el badge vivo
-
+    - cron: "0 6 * * 1" # opcional: semanal para mantener el badge vivo
 permissions:
   contents: read
 
@@ -12,5 +10,6 @@ jobs:
   py:
     uses: ./.github/workflows/py-ci.yml
     with:
-      py-versions: '["3.11","3.12"]'
-      cov-min: 0
+      os: ubuntu-latest
+      python_versions: '["3.11","3.12"]'
+      run_tests: false # solo smoke para el badge (sin tests)

--- a/.github/workflows/py-ci-badge.yml
+++ b/.github/workflows/py-ci-badge.yml
@@ -1,16 +1,18 @@
 name: Python CI (reusable)
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
   schedule:
-    - cron: "0 6 * * 1" # semanal (lu 06:00 UTC) sólo para refrescar el badge
+    - cron: "0 6 * * 1"
 
 permissions:
   contents: read
 
 jobs:
   badge:
-    uses: ./.github/workflows/py-ci.yml
+    uses: CoderDeltaLAN/ci-matrix-starter/.github/workflows/py-ci.yml@main
     with:
+      os: '["ubuntu-latest"]'
       python_versions: '["3.12"]'
       run_tests: false
-    secrets: inherit


### PR DESCRIPTION
Arreglo del wrapper para el badge usando el reusable con inputs válidos.