### PR TITLE
ci: fix Scorecard action pin to v2.4.2

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard (private publish)
-        uses: ossf/scorecard-action@43e475b79a8bd5217334edc08879005b2229d79a.4.2
+        uses: ossf/scorecard-action@v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Pin ossf/scorecard-action to v2.4.2. Validated locally with pre-commit and actionlint.